### PR TITLE
feat: Add web scraping and code fetching tools

### DIFF
--- a/cmd/mcp-server/main.go
+++ b/cmd/mcp-server/main.go
@@ -84,6 +84,12 @@ func main() {
 	listJobsTool := tools.NewListJobsTool(jobManager)
 	cancelJobTool := tools.NewCancelJobTool(jobManager)
 
+	// Create web scraping tool (only if enabled)
+	var webScrapeTool *tools.WebScrapeTool
+	if cfg.WebScraping.Enabled {
+		webScrapeTool = tools.NewWebScrapeTool(cfg, nil) // Token manager will be set later if available
+	}
+
 	// Initialize repo management system
 	var repoStore repos.Store
 	if cfg.RepoStorage.DatabasePath != "" {
@@ -124,6 +130,9 @@ func main() {
 	server.RegisterTool(listJobsTool)
 	server.RegisterTool(cancelJobTool)
 	server.RegisterTool(repoTool)
+	if webScrapeTool != nil {
+		server.RegisterTool(webScrapeTool)
+	}
 
 	// Create and register agents with all tools
 	builderAgent := agents.NewBuilderAgent(cfg, backend, jobManager)
@@ -135,6 +144,9 @@ func main() {
 	builderAgent.RegisterTool(bashTool)
 	builderAgent.RegisterTool(testTool)
 	builderAgent.RegisterTool(repoTool)
+	if webScrapeTool != nil {
+		builderAgent.RegisterTool(webScrapeTool)
+	}
 
 	reviewerAgent := agents.NewReviewerAgent(cfg, backend, jobManager)
 	reviewerAgent.RegisterTool(fileTool)
@@ -145,6 +157,9 @@ func main() {
 	reviewerAgent.RegisterTool(bashTool)
 	reviewerAgent.RegisterTool(testTool)
 	reviewerAgent.RegisterTool(repoTool)
+	if webScrapeTool != nil {
+		reviewerAgent.RegisterTool(webScrapeTool)
+	}
 
 	debuggerAgent := agents.NewDebuggerAgent(cfg, backend, jobManager)
 	debuggerAgent.RegisterTool(fileTool)
@@ -155,6 +170,9 @@ func main() {
 	debuggerAgent.RegisterTool(bashTool)
 	debuggerAgent.RegisterTool(testTool)
 	debuggerAgent.RegisterTool(repoTool)
+	if webScrapeTool != nil {
+		debuggerAgent.RegisterTool(webScrapeTool)
+	}
 
 	triagerAgent := agents.NewTriagerAgent(cfg, backend, jobManager)
 	triagerAgent.RegisterTool(fileTool)
@@ -165,6 +183,9 @@ func main() {
 	triagerAgent.RegisterTool(bashTool)
 	triagerAgent.RegisterTool(testTool)
 	triagerAgent.RegisterTool(repoTool)
+	if webScrapeTool != nil {
+		triagerAgent.RegisterTool(webScrapeTool)
+	}
 
 	// Create token manager for podcast tools (only if podcast mode is enabled)
 	var tokenManager *tokens.Manager

--- a/docs/webscraping-tool.md
+++ b/docs/webscraping-tool.md
@@ -1,0 +1,431 @@
+# Web Scraping & Code Fetching Tool
+
+This document describes the web scraping and code fetching capabilities in PedroCLI, which enables agents to fetch current information from the web, pull code examples from public repositories, and search for solutions on Q&A sites.
+
+## Overview
+
+The web scraping tool provides agents with the ability to:
+
+- Fetch and extract content from any URL
+- Search the web using DuckDuckGo or SearXNG
+- Fetch files and directories from GitHub repositories
+- Fetch files from GitLab repositories (including self-hosted instances)
+- Search and fetch Stack Overflow questions and answers
+- Extract code blocks from web pages
+
+This is particularly useful when:
+- Self-hosted models have knowledge cutoffs and can't browse
+- Agents need access to current documentation or API references
+- Code examples from GitHub/GitLab/Stack Overflow are needed for coding tasks
+
+## Architecture
+
+### Package Structure
+
+```
+pkg/webscrape/
+├── types.go          # Core type definitions
+├── fetcher.go        # HTTP fetcher with caching and rate limiting
+├── extractor.go      # HTML content extraction (text, code blocks)
+├── cache.go          # Caching layer (SQLite or in-memory)
+├── ratelimit.go      # Per-domain rate limiting
+├── search.go         # Search engine integrations
+└── handlers/
+    ├── github.go     # GitHub API handler
+    ├── gitlab.go     # GitLab API handler
+    └── stackoverflow.go  # Stack Exchange API handler
+
+pkg/tools/
+└── webscrape.go      # MCP tool wrapper
+```
+
+### Component Diagram
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     WebScrapeTool (MCP)                     │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  ┌─────────────┐  ┌─────────────┐  ┌───────────────────┐   │
+│  │   Fetcher   │  │   Search    │  │  Site Handlers    │   │
+│  │ (HTTP/HTTPS)│  │  Engines    │  │ GitHub/GitLab/SO  │   │
+│  └──────┬──────┘  └──────┬──────┘  └─────────┬─────────┘   │
+│         │                │                   │              │
+│  ┌──────┴──────┐  ┌──────┴──────┐           │              │
+│  │  Extractor  │  │ DuckDuckGo  │           │              │
+│  │ (HTML→Text) │  │   SearXNG   │           │              │
+│  └─────────────┘  └─────────────┘           │              │
+│                                             │              │
+│  ┌───────────────────────────────────────────┐             │
+│  │         Rate Limiter (per-domain)         │             │
+│  └───────────────────────────────────────────┘             │
+│                                                             │
+│  ┌───────────────────────────────────────────┐             │
+│  │     Cache (SQLite or In-Memory)           │             │
+│  └───────────────────────────────────────────┘             │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## MCP Tool Actions
+
+The `web_scrape` tool exposes the following actions:
+
+### Generic Fetching
+
+#### `fetch_url`
+Fetch content from any URL, optionally extracting clean text and code blocks.
+
+```json
+{
+  "action": "fetch_url",
+  "url": "https://example.com/page",
+  "extract_text": true,
+  "extract_code": true
+}
+```
+
+#### `extract_code_from_url`
+Extract all code blocks from a webpage, optionally filtered by language.
+
+```json
+{
+  "action": "extract_code_from_url",
+  "url": "https://example.com/tutorial",
+  "language": "python"
+}
+```
+
+### Web Search
+
+#### `search_web`
+Search the web for information using DuckDuckGo or SearXNG.
+
+```json
+{
+  "action": "search_web",
+  "query": "golang http client example",
+  "max_results": 10,
+  "site": "stackoverflow.com"
+}
+```
+
+### GitHub
+
+#### `fetch_github_file`
+Fetch a specific file from a GitHub repository.
+
+```json
+{
+  "action": "fetch_github_file",
+  "owner": "golang",
+  "repo": "go",
+  "path": "src/net/http/client.go",
+  "ref": "master"
+}
+```
+
+#### `fetch_github_readme`
+Fetch the README from a GitHub repository.
+
+```json
+{
+  "action": "fetch_github_readme",
+  "owner": "golang",
+  "repo": "go"
+}
+```
+
+#### `fetch_github_directory`
+List files in a GitHub repository directory.
+
+```json
+{
+  "action": "fetch_github_directory",
+  "owner": "golang",
+  "repo": "go",
+  "path": "src/net/http",
+  "ref": "master"
+}
+```
+
+#### `search_github_code`
+Search for code on GitHub.
+
+```json
+{
+  "action": "search_github_code",
+  "query": "func ServeHTTP",
+  "language": "go",
+  "repo": "golang/go"
+}
+```
+
+### GitLab
+
+#### `fetch_gitlab_file`
+Fetch a file from a GitLab repository.
+
+```json
+{
+  "action": "fetch_gitlab_file",
+  "project": "gitlab-org/gitlab",
+  "path": "README.md",
+  "ref": "main"
+}
+```
+
+#### `fetch_gitlab_readme`
+Fetch the README from a GitLab repository.
+
+```json
+{
+  "action": "fetch_gitlab_readme",
+  "project": "gitlab-org/gitlab"
+}
+```
+
+### Stack Overflow
+
+#### `fetch_stackoverflow_question`
+Fetch a Stack Overflow question with its answers.
+
+```json
+{
+  "action": "fetch_stackoverflow_question",
+  "question_id": 12345678,
+  "include_answers": true,
+  "max_answers": 5
+}
+```
+
+#### `search_stackoverflow`
+Search Stack Overflow for questions.
+
+```json
+{
+  "action": "search_stackoverflow",
+  "query": "golang http client timeout",
+  "tags": "go,http",
+  "sort": "relevance",
+  "max_results": 10
+}
+```
+
+## Configuration
+
+Add the following to your `.pedrocli.json`:
+
+```json
+{
+  "web_scraping": {
+    "enabled": true,
+    "user_agent": "PedroCLI/1.0 (Web Scraping Tool)",
+    "timeout_seconds": 30,
+    "max_size_mb": 10,
+
+    "cache_enabled": true,
+    "cache_type": "memory",
+    "cache_ttl_hours": 1,
+    "cache_max_size_mb": 100,
+
+    "search_engine": "duckduckgo",
+    "searxng_url": "",
+
+    "github_token": "",
+    "gitlab_token": "",
+    "gitlab_url": "https://gitlab.com",
+    "stackoverflow_key": ""
+  }
+}
+```
+
+### Configuration Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `enabled` | `false` | Enable/disable web scraping |
+| `user_agent` | `PedroCLI/1.0` | HTTP User-Agent header |
+| `timeout_seconds` | `30` | HTTP request timeout |
+| `max_size_mb` | `10` | Maximum response size in MB |
+| `cache_enabled` | `true` | Enable response caching |
+| `cache_type` | `memory` | Cache type: `memory` or `sqlite` |
+| `cache_ttl_hours` | `1` | Default cache TTL |
+| `cache_max_size_mb` | `100` | Maximum cache size |
+| `search_engine` | `duckduckgo` | Search engine: `duckduckgo` or `searxng` |
+| `searxng_url` | `` | SearXNG instance URL (if using) |
+| `github_token` | `` | GitHub API token (optional) |
+| `gitlab_token` | `` | GitLab API token (optional) |
+| `gitlab_url` | `https://gitlab.com` | GitLab instance URL |
+| `stackoverflow_key` | `` | Stack Exchange API key (optional) |
+
+### Environment Variables
+
+API tokens can also be set via environment variables:
+
+- `GITHUB_TOKEN` - GitHub API token
+- `GITLAB_TOKEN` - GitLab API token
+- `SO_API_KEY` - Stack Exchange API key
+
+## Rate Limiting
+
+The tool implements per-domain rate limiting to be respectful to external services:
+
+| Domain | Default Rate (req/s) |
+|--------|---------------------|
+| `github.com` | 10 |
+| `api.github.com` | 30 (with token) |
+| `gitlab.com` | 10 |
+| `stackoverflow.com` | 30 |
+| Default | 2 |
+
+Rate limits can be customized via configuration:
+
+```json
+{
+  "web_scraping": {
+    "rate_limits": {
+      "github.com": 15,
+      "my-gitlab.example.com": 20,
+      "default": 5
+    }
+  }
+}
+```
+
+## Caching
+
+The cache layer helps reduce API calls and improve response times:
+
+### In-Memory Cache (Default)
+- Fast access
+- Lost on restart
+- Configurable max size
+
+### SQLite Cache
+- Persistent across restarts
+- Automatic cleanup of expired entries
+- Good for larger caches
+
+Configure SQLite cache:
+
+```json
+{
+  "web_scraping": {
+    "cache_type": "sqlite",
+    "cache_path": "/var/pedro/cache/webscrape.db"
+  }
+}
+```
+
+## Content Extraction
+
+### HTML to Clean Text
+
+The extractor removes:
+- `<script>` and `<style>` tags
+- Navigation, header, footer elements
+- HTML comments
+- Converts block elements to newlines
+- Decodes HTML entities
+
+### Code Block Extraction
+
+Detects and extracts code from:
+- `<pre><code>` blocks with language classes
+- Standalone `<pre>` blocks
+- Fenced markdown code blocks (\`\`\`language)
+
+Language detection is performed based on:
+- HTML class attributes (e.g., `language-python`)
+- Heuristic analysis of code content
+
+## Error Handling
+
+The tool returns structured errors with suggestions for agents:
+
+| Error Type | Description | Suggestion |
+|------------|-------------|------------|
+| `rate_limited` | API rate limit exceeded | Wait before retrying |
+| `not_found` | Resource not found | Verify URL/path |
+| `access_denied` | Authentication required | Check token/permissions |
+| `timeout` | Request timed out | Retry or increase timeout |
+| `invalid_url` | Malformed URL | Check URL format |
+| `parse_failure` | Content parsing failed | Page format may be unsupported |
+| `network_error` | Network connectivity issue | Check connectivity |
+
+## Response Format
+
+All responses are formatted as JSON for easy agent consumption:
+
+```json
+{
+  "success": true,
+  "source": "https://example.com/page",
+  "content_type": "mixed",
+  "summary": "Page Title - Brief description",
+  "content": "Clean text content...",
+  "code_blocks": [
+    {
+      "language": "python",
+      "code": "def hello(): ...",
+      "description": "Example function"
+    }
+  ],
+  "links": [
+    {
+      "text": "Documentation",
+      "url": "https://docs.example.com",
+      "type": "documentation"
+    }
+  ],
+  "metadata": {
+    "title": "Page Title",
+    "fetched_at": "2024-01-15T10:30:00Z"
+  }
+}
+```
+
+## Security Considerations
+
+1. **Token Security**: API tokens are stored in configuration, not exposed to LLMs
+2. **Rate Limiting**: Prevents abuse of external APIs
+3. **Size Limits**: Maximum response size prevents memory exhaustion
+4. **URL Validation**: Only HTTP/HTTPS URLs are allowed
+5. **Timeout Limits**: Prevents hanging on slow responses
+
+## Best Practices
+
+1. **Use Caching**: Enable caching to reduce API calls
+2. **Set API Tokens**: Tokens increase rate limits significantly
+3. **Prefer Site-Specific Actions**: Use `fetch_github_file` over `fetch_url` for GitHub
+4. **Limit Results**: Set appropriate `max_results` to reduce response size
+5. **Filter by Language**: When extracting code, specify the language filter
+
+## Troubleshooting
+
+### Rate Limit Errors
+- Enable caching to reduce repeated requests
+- Add API tokens for higher limits
+- Increase wait time between requests
+
+### Content Not Extracted
+- Some pages may use JavaScript rendering (not supported)
+- Check if the page is actually accessible
+- Try the site-specific handler if available
+
+### Cache Issues
+- Clear cache by deleting the SQLite file or restarting (memory cache)
+- Check cache TTL settings
+- Verify cache directory permissions (SQLite)
+
+## Future Enhancements
+
+TODO items for future development:
+
+- [ ] Google Custom Search integration (requires API key)
+- [ ] JavaScript rendering support (headless browser)
+- [ ] Additional site handlers (Bitbucket, SourceHut)
+- [ ] Automatic language detection improvement
+- [ ] PDF and documentation site parsing
+- [ ] WebSocket support for real-time pages

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,6 +30,8 @@ type Config struct {
 	Podcast PodcastConfig `json:"podcast,omitempty"`
 	// OAuth configuration for external services
 	OAuth OAuthConfig `json:"oauth,omitempty"`
+	// Web scraping configuration
+	WebScraping WebScrapingConfig `json:"web_scraping,omitempty"`
 }
 
 // ModelConfig contains model configuration
@@ -254,6 +256,36 @@ type GoogleOAuthConfig struct {
 	RedirectURI string `json:"redirect_uri,omitempty"`
 }
 
+// WebScrapingConfig contains web scraping configuration
+type WebScrapingConfig struct {
+	Enabled bool `json:"enabled"`
+	// HTTP client settings
+	UserAgent      string `json:"user_agent,omitempty"`
+	TimeoutSeconds int    `json:"timeout_seconds,omitempty"`
+	MaxSizeMB      int    `json:"max_size_mb,omitempty"`
+	// Rate limiting (requests per second per domain)
+	RateLimits map[string]float64 `json:"rate_limits,omitempty"`
+	// Caching
+	CacheEnabled   bool   `json:"cache_enabled"`
+	CacheType      string `json:"cache_type,omitempty"` // "sqlite", "memory"
+	CachePath      string `json:"cache_path,omitempty"`
+	CacheTTLHours  int    `json:"cache_ttl_hours,omitempty"`
+	CacheMaxSizeMB int64  `json:"cache_max_size_mb,omitempty"`
+	// API tokens (optional, for higher rate limits)
+	// These can also be set via environment variables:
+	// GITHUB_TOKEN, GITLAB_TOKEN, SO_API_KEY
+	GitHubToken      string `json:"github_token,omitempty"`
+	GitLabToken      string `json:"gitlab_token,omitempty"`
+	StackOverflowKey string `json:"stackoverflow_key,omitempty"`
+	GoogleSearchKey  string `json:"google_search_key,omitempty"`
+	GoogleSearchCX   string `json:"google_search_cx,omitempty"`
+	// Search engine preference
+	SearchEngine string `json:"search_engine,omitempty"` // "duckduckgo", "google", "searxng"
+	SearXNGURL   string `json:"searxng_url,omitempty"`   // For self-hosted SearXNG
+	// GitLab instance URL (for self-hosted)
+	GitLabURL string `json:"gitlab_url,omitempty"`
+}
+
 // GetModelConfig returns the model configuration for a given profile name.
 // If the profile is empty or not found, returns the default Model config.
 func (c *Config) GetModelConfig(profile string) ModelConfig {
@@ -457,6 +489,32 @@ func (c *Config) setDefaults() {
 	if c.Podcast.Calendar.Command == "" {
 		// Use our built-in calendar MCP server
 		c.Podcast.Calendar.Command = "./pedrocli-calendar-mcp"
+	}
+
+	// Web scraping defaults
+	if c.WebScraping.UserAgent == "" {
+		c.WebScraping.UserAgent = "PedroCLI/1.0 (Web Scraping Tool)"
+	}
+	if c.WebScraping.TimeoutSeconds == 0 {
+		c.WebScraping.TimeoutSeconds = 30
+	}
+	if c.WebScraping.MaxSizeMB == 0 {
+		c.WebScraping.MaxSizeMB = 10
+	}
+	if c.WebScraping.CacheType == "" {
+		c.WebScraping.CacheType = "memory"
+	}
+	if c.WebScraping.CacheTTLHours == 0 {
+		c.WebScraping.CacheTTLHours = 1
+	}
+	if c.WebScraping.CacheMaxSizeMB == 0 {
+		c.WebScraping.CacheMaxSizeMB = 100
+	}
+	if c.WebScraping.SearchEngine == "" {
+		c.WebScraping.SearchEngine = "duckduckgo"
+	}
+	if c.WebScraping.GitLabURL == "" {
+		c.WebScraping.GitLabURL = "https://gitlab.com"
 	}
 }
 

--- a/pkg/tools/webscrape.go
+++ b/pkg/tools/webscrape.go
@@ -1,0 +1,514 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/soypete/pedrocli/pkg/config"
+	"github.com/soypete/pedrocli/pkg/webscrape"
+	"github.com/soypete/pedrocli/pkg/webscrape/handlers"
+)
+
+// WebScrapeTool provides web scraping capabilities via MCP
+type WebScrapeTool struct {
+	config           *config.Config
+	fetcher          *webscrape.HTTPFetcher
+	githubHandler    *handlers.GitHubHandler
+	gitlabHandler    *handlers.GitLabHandler
+	stackoverHandler *handlers.StackOverflowHandler
+	searchEngine     webscrape.SearchEngine
+}
+
+// NewWebScrapeTool creates a new web scraping tool
+func NewWebScrapeTool(cfg *config.Config, tokenManager TokenManager) *WebScrapeTool {
+	// Get tokens if available
+	var githubToken, gitlabToken, soAPIKey string
+	if tokenManager != nil {
+		ctx := context.Background()
+		githubToken, _ = tokenManager.GetToken(ctx, "github", "api")
+		gitlabToken, _ = tokenManager.GetToken(ctx, "gitlab", "api")
+		soAPIKey, _ = tokenManager.GetToken(ctx, "stackoverflow", "api")
+	}
+
+	// Create HTTP fetcher
+	fetcherCfg := webscrape.DefaultFetcherConfig()
+	if cfg != nil && cfg.WebScraping.UserAgent != "" {
+		fetcherCfg.UserAgent = cfg.WebScraping.UserAgent
+	}
+	fetcher, _ := webscrape.NewHTTPFetcher(fetcherCfg)
+
+	// Create handlers
+	githubHandler := handlers.NewGitHubHandler(&handlers.GitHubConfig{
+		APIToken: githubToken,
+	})
+
+	gitlabHandler := handlers.NewGitLabHandler(&handlers.GitLabConfig{
+		APIToken: gitlabToken,
+	})
+
+	stackoverHandler := handlers.NewStackOverflowHandler(&handlers.StackOverflowConfig{
+		APIKey: soAPIKey,
+	})
+
+	// Create search engine
+	var searchEngine webscrape.SearchEngine
+	if cfg != nil && cfg.WebScraping.SearXNGURL != "" {
+		searchEngine = webscrape.NewSearXNGSearch(cfg.WebScraping.SearXNGURL)
+	} else {
+		searchEngine = webscrape.NewDuckDuckGoSearch()
+	}
+
+	return &WebScrapeTool{
+		config:           cfg,
+		fetcher:          fetcher,
+		githubHandler:    githubHandler,
+		gitlabHandler:    gitlabHandler,
+		stackoverHandler: stackoverHandler,
+		searchEngine:     searchEngine,
+	}
+}
+
+// Name returns the tool name
+func (w *WebScrapeTool) Name() string {
+	return "web_scrape"
+}
+
+// Description returns the tool description
+func (w *WebScrapeTool) Description() string {
+	return `Web scraping and code fetching tool. Actions:
+- fetch_url: Fetch content from a URL, extract clean text and code blocks
+- search_web: Search the web for information
+- fetch_github_file: Fetch a file from a GitHub repository
+- fetch_github_readme: Fetch README from a GitHub repository
+- fetch_github_directory: List files in a GitHub repository directory
+- search_github_code: Search for code on GitHub
+- fetch_gitlab_file: Fetch a file from a GitLab repository
+- fetch_gitlab_readme: Fetch README from a GitLab repository
+- fetch_stackoverflow_question: Fetch a Stack Overflow question with answers
+- search_stackoverflow: Search Stack Overflow for questions
+- extract_code_from_url: Extract all code blocks from a webpage`
+}
+
+// Execute executes the web scraping tool
+func (w *WebScrapeTool) Execute(ctx context.Context, args map[string]interface{}) (*Result, error) {
+	action, ok := args["action"].(string)
+	if !ok {
+		return &Result{Success: false, Error: "missing 'action' parameter"}, nil
+	}
+
+	switch action {
+	case "fetch_url":
+		return w.fetchURL(ctx, args)
+	case "search_web":
+		return w.searchWeb(ctx, args)
+	case "fetch_github_file":
+		return w.fetchGitHubFile(ctx, args)
+	case "fetch_github_readme":
+		return w.fetchGitHubREADME(ctx, args)
+	case "fetch_github_directory":
+		return w.fetchGitHubDirectory(ctx, args)
+	case "search_github_code":
+		return w.searchGitHubCode(ctx, args)
+	case "fetch_gitlab_file":
+		return w.fetchGitLabFile(ctx, args)
+	case "fetch_gitlab_readme":
+		return w.fetchGitLabREADME(ctx, args)
+	case "fetch_stackoverflow_question":
+		return w.fetchSOQuestion(ctx, args)
+	case "search_stackoverflow":
+		return w.searchStackOverflow(ctx, args)
+	case "extract_code_from_url":
+		return w.extractCodeFromURL(ctx, args)
+	default:
+		return &Result{Success: false, Error: fmt.Sprintf("unknown action: %s", action)}, nil
+	}
+}
+
+// fetchURL fetches content from a URL
+func (w *WebScrapeTool) fetchURL(ctx context.Context, args map[string]interface{}) (*Result, error) {
+	url, ok := args["url"].(string)
+	if !ok {
+		return &Result{Success: false, Error: "missing 'url' parameter"}, nil
+	}
+
+	opts := webscrape.DefaultFetchOptions()
+
+	if extractText, ok := args["extract_text"].(bool); ok {
+		opts.ExtractContent = extractText
+	}
+	if extractCode, ok := args["extract_code"].(bool); ok {
+		opts.ExtractCode = extractCode
+	}
+
+	result, err := w.fetcher.Fetch(ctx, url, opts)
+	if err != nil {
+		if scrapeErr, ok := err.(*webscrape.ScrapeError); ok {
+			return &Result{Success: false, Error: scrapeErr.ForAgent()}, nil
+		}
+		return &Result{Success: false, Error: err.Error()}, nil
+	}
+
+	// Format response for agent
+	resp := webscrape.FormatForAgent(result)
+	output, _ := json.MarshalIndent(resp, "", "  ")
+
+	return &Result{
+		Success: true,
+		Output:  string(output),
+	}, nil
+}
+
+// searchWeb performs a web search
+func (w *WebScrapeTool) searchWeb(ctx context.Context, args map[string]interface{}) (*Result, error) {
+	query, ok := args["query"].(string)
+	if !ok {
+		return &Result{Success: false, Error: "missing 'query' parameter"}, nil
+	}
+
+	opts := webscrape.DefaultSearchOptions()
+
+	if maxResults, ok := args["max_results"].(float64); ok {
+		opts.MaxResults = int(maxResults)
+	}
+	if site, ok := args["site"].(string); ok {
+		opts.Site = site
+	}
+
+	results, err := w.searchEngine.Search(ctx, query, opts)
+	if err != nil {
+		if scrapeErr, ok := err.(*webscrape.ScrapeError); ok {
+			return &Result{Success: false, Error: scrapeErr.ForAgent()}, nil
+		}
+		return &Result{Success: false, Error: err.Error()}, nil
+	}
+
+	output, _ := json.MarshalIndent(results, "", "  ")
+
+	return &Result{
+		Success: true,
+		Output:  string(output),
+	}, nil
+}
+
+// fetchGitHubFile fetches a file from GitHub
+func (w *WebScrapeTool) fetchGitHubFile(ctx context.Context, args map[string]interface{}) (*Result, error) {
+	owner, _ := args["owner"].(string)
+	repo, _ := args["repo"].(string)
+	path, _ := args["path"].(string)
+	ref, _ := args["ref"].(string)
+
+	if owner == "" || repo == "" || path == "" {
+		return &Result{Success: false, Error: "missing required parameters: owner, repo, path"}, nil
+	}
+
+	if ref == "" {
+		ref = "main"
+	}
+
+	file, err := w.githubHandler.FetchFile(ctx, owner, repo, path, ref)
+	if err != nil {
+		if scrapeErr, ok := err.(*webscrape.ScrapeError); ok {
+			return &Result{Success: false, Error: scrapeErr.ForAgent()}, nil
+		}
+		return &Result{Success: false, Error: err.Error()}, nil
+	}
+
+	output, _ := json.MarshalIndent(file, "", "  ")
+
+	return &Result{
+		Success: true,
+		Output:  string(output),
+	}, nil
+}
+
+// fetchGitHubREADME fetches a README from GitHub
+func (w *WebScrapeTool) fetchGitHubREADME(ctx context.Context, args map[string]interface{}) (*Result, error) {
+	owner, _ := args["owner"].(string)
+	repo, _ := args["repo"].(string)
+
+	if owner == "" || repo == "" {
+		return &Result{Success: false, Error: "missing required parameters: owner, repo"}, nil
+	}
+
+	file, err := w.githubHandler.FetchREADME(ctx, owner, repo)
+	if err != nil {
+		if scrapeErr, ok := err.(*webscrape.ScrapeError); ok {
+			return &Result{Success: false, Error: scrapeErr.ForAgent()}, nil
+		}
+		return &Result{Success: false, Error: err.Error()}, nil
+	}
+
+	output, _ := json.MarshalIndent(file, "", "  ")
+
+	return &Result{
+		Success: true,
+		Output:  string(output),
+	}, nil
+}
+
+// fetchGitHubDirectory lists files in a GitHub directory
+func (w *WebScrapeTool) fetchGitHubDirectory(ctx context.Context, args map[string]interface{}) (*Result, error) {
+	owner, _ := args["owner"].(string)
+	repo, _ := args["repo"].(string)
+	path, _ := args["path"].(string)
+	ref, _ := args["ref"].(string)
+
+	if owner == "" || repo == "" {
+		return &Result{Success: false, Error: "missing required parameters: owner, repo"}, nil
+	}
+
+	if ref == "" {
+		ref = "main"
+	}
+
+	entries, err := w.githubHandler.FetchDirectory(ctx, owner, repo, path, ref)
+	if err != nil {
+		if scrapeErr, ok := err.(*webscrape.ScrapeError); ok {
+			return &Result{Success: false, Error: scrapeErr.ForAgent()}, nil
+		}
+		return &Result{Success: false, Error: err.Error()}, nil
+	}
+
+	output, _ := json.MarshalIndent(entries, "", "  ")
+
+	return &Result{
+		Success: true,
+		Output:  string(output),
+	}, nil
+}
+
+// searchGitHubCode searches for code on GitHub
+func (w *WebScrapeTool) searchGitHubCode(ctx context.Context, args map[string]interface{}) (*Result, error) {
+	query, _ := args["query"].(string)
+	if query == "" {
+		return &Result{Success: false, Error: "missing 'query' parameter"}, nil
+	}
+
+	opts := &webscrape.GitHubSearchOpts{}
+	if language, ok := args["language"].(string); ok {
+		opts.Language = language
+	}
+	if repo, ok := args["repo"].(string); ok {
+		opts.Repo = repo
+	}
+
+	results, err := w.githubHandler.SearchCode(ctx, query, opts)
+	if err != nil {
+		if scrapeErr, ok := err.(*webscrape.ScrapeError); ok {
+			return &Result{Success: false, Error: scrapeErr.ForAgent()}, nil
+		}
+		return &Result{Success: false, Error: err.Error()}, nil
+	}
+
+	output, _ := json.MarshalIndent(results, "", "  ")
+
+	return &Result{
+		Success: true,
+		Output:  string(output),
+	}, nil
+}
+
+// fetchGitLabFile fetches a file from GitLab
+func (w *WebScrapeTool) fetchGitLabFile(ctx context.Context, args map[string]interface{}) (*Result, error) {
+	project, _ := args["project"].(string)
+	path, _ := args["path"].(string)
+	ref, _ := args["ref"].(string)
+
+	if project == "" || path == "" {
+		return &Result{Success: false, Error: "missing required parameters: project, path"}, nil
+	}
+
+	if ref == "" {
+		ref = "main"
+	}
+
+	file, err := w.gitlabHandler.FetchFile(ctx, project, path, ref)
+	if err != nil {
+		if scrapeErr, ok := err.(*webscrape.ScrapeError); ok {
+			return &Result{Success: false, Error: scrapeErr.ForAgent()}, nil
+		}
+		return &Result{Success: false, Error: err.Error()}, nil
+	}
+
+	output, _ := json.MarshalIndent(file, "", "  ")
+
+	return &Result{
+		Success: true,
+		Output:  string(output),
+	}, nil
+}
+
+// fetchGitLabREADME fetches a README from GitLab
+func (w *WebScrapeTool) fetchGitLabREADME(ctx context.Context, args map[string]interface{}) (*Result, error) {
+	project, _ := args["project"].(string)
+
+	if project == "" {
+		return &Result{Success: false, Error: "missing 'project' parameter"}, nil
+	}
+
+	file, err := w.gitlabHandler.FetchREADME(ctx, project)
+	if err != nil {
+		if scrapeErr, ok := err.(*webscrape.ScrapeError); ok {
+			return &Result{Success: false, Error: scrapeErr.ForAgent()}, nil
+		}
+		return &Result{Success: false, Error: err.Error()}, nil
+	}
+
+	output, _ := json.MarshalIndent(file, "", "  ")
+
+	return &Result{
+		Success: true,
+		Output:  string(output),
+	}, nil
+}
+
+// fetchSOQuestion fetches a Stack Overflow question
+func (w *WebScrapeTool) fetchSOQuestion(ctx context.Context, args map[string]interface{}) (*Result, error) {
+	var questionID int
+
+	// Accept question_id as either string or number
+	switch v := args["question_id"].(type) {
+	case float64:
+		questionID = int(v)
+	case string:
+		var err error
+		questionID, err = strconv.Atoi(v)
+		if err != nil {
+			return &Result{Success: false, Error: "invalid question_id format"}, nil
+		}
+	default:
+		return &Result{Success: false, Error: "missing 'question_id' parameter"}, nil
+	}
+
+	includeAnswers := true
+	if ia, ok := args["include_answers"].(bool); ok {
+		includeAnswers = ia
+	}
+
+	maxAnswers := 5
+	if ma, ok := args["max_answers"].(float64); ok {
+		maxAnswers = int(ma)
+	}
+
+	var question *webscrape.SOQuestion
+	var err error
+
+	if includeAnswers {
+		question, err = w.stackoverHandler.FetchQuestionWithAnswers(ctx, questionID, maxAnswers)
+	} else {
+		question, err = w.stackoverHandler.FetchQuestion(ctx, questionID)
+	}
+
+	if err != nil {
+		if scrapeErr, ok := err.(*webscrape.ScrapeError); ok {
+			return &Result{Success: false, Error: scrapeErr.ForAgent()}, nil
+		}
+		return &Result{Success: false, Error: err.Error()}, nil
+	}
+
+	output, _ := json.MarshalIndent(question, "", "  ")
+
+	return &Result{
+		Success: true,
+		Output:  string(output),
+	}, nil
+}
+
+// searchStackOverflow searches Stack Overflow
+func (w *WebScrapeTool) searchStackOverflow(ctx context.Context, args map[string]interface{}) (*Result, error) {
+	query, _ := args["query"].(string)
+	if query == "" {
+		return &Result{Success: false, Error: "missing 'query' parameter"}, nil
+	}
+
+	var tags []string
+	if tagsStr, ok := args["tags"].(string); ok && tagsStr != "" {
+		tags = strings.Split(tagsStr, ",")
+		for i, t := range tags {
+			tags[i] = strings.TrimSpace(t)
+		}
+	}
+
+	sort := "relevance"
+	if s, ok := args["sort"].(string); ok {
+		sort = s
+	}
+
+	maxResults := 10
+	if mr, ok := args["max_results"].(float64); ok {
+		maxResults = int(mr)
+	}
+
+	results, err := w.stackoverHandler.SearchQuestions(ctx, query, tags, sort, maxResults)
+	if err != nil {
+		if scrapeErr, ok := err.(*webscrape.ScrapeError); ok {
+			return &Result{Success: false, Error: scrapeErr.ForAgent()}, nil
+		}
+		return &Result{Success: false, Error: err.Error()}, nil
+	}
+
+	output, _ := json.MarshalIndent(results, "", "  ")
+
+	return &Result{
+		Success: true,
+		Output:  string(output),
+	}, nil
+}
+
+// extractCodeFromURL extracts code blocks from a URL
+func (w *WebScrapeTool) extractCodeFromURL(ctx context.Context, args map[string]interface{}) (*Result, error) {
+	url, _ := args["url"].(string)
+	if url == "" {
+		return &Result{Success: false, Error: "missing 'url' parameter"}, nil
+	}
+
+	language, _ := args["language"].(string)
+
+	opts := webscrape.DefaultFetchOptions()
+	opts.ExtractCode = true
+
+	result, err := w.fetcher.Fetch(ctx, url, opts)
+	if err != nil {
+		if scrapeErr, ok := err.(*webscrape.ScrapeError); ok {
+			return &Result{Success: false, Error: scrapeErr.ForAgent()}, nil
+		}
+		return &Result{Success: false, Error: err.Error()}, nil
+	}
+
+	// Filter by language if specified
+	var codeBlocks []webscrape.CodeBlock
+	if language != "" {
+		for _, block := range result.CodeBlocks {
+			if strings.EqualFold(block.Language, language) {
+				codeBlocks = append(codeBlocks, block)
+			}
+		}
+	} else {
+		codeBlocks = result.CodeBlocks
+	}
+
+	if len(codeBlocks) == 0 {
+		return &Result{
+			Success: true,
+			Output:  "No code blocks found",
+		}, nil
+	}
+
+	output, _ := json.MarshalIndent(codeBlocks, "", "  ")
+
+	return &Result{
+		Success: true,
+		Output:  string(output),
+	}, nil
+}
+
+// Close cleans up resources
+func (w *WebScrapeTool) Close() error {
+	if w.fetcher != nil {
+		return w.fetcher.Close()
+	}
+	return nil
+}

--- a/pkg/webscrape/cache.go
+++ b/pkg/webscrape/cache.go
@@ -1,0 +1,368 @@
+package webscrape
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// CacheStore defines the interface for cache storage
+type CacheStore interface {
+	Get(urlHash string) (*CacheEntry, error)
+	Set(entry *CacheEntry) error
+	Delete(urlHash string) error
+	Cleanup() error // Remove expired entries
+	Close() error
+}
+
+// Cache provides caching for fetch results
+type Cache struct {
+	store      CacheStore
+	defaultTTL time.Duration
+	enabled    bool
+}
+
+// CacheConfig configures the cache behavior
+type CacheConfig struct {
+	Enabled    bool          `json:"enabled"`
+	Type       string        `json:"type"` // "sqlite", "memory"
+	Path       string        `json:"path,omitempty"`
+	DefaultTTL time.Duration `json:"default_ttl"`
+	MaxSizeMB  int64         `json:"max_size_mb"`
+}
+
+// DefaultCacheConfig returns default cache configuration
+func DefaultCacheConfig() *CacheConfig {
+	return &CacheConfig{
+		Enabled:    true,
+		Type:       "memory",
+		DefaultTTL: 1 * time.Hour,
+		MaxSizeMB:  100,
+	}
+}
+
+// NewCache creates a new cache with the given configuration
+func NewCache(cfg *CacheConfig) (*Cache, error) {
+	if !cfg.Enabled {
+		return &Cache{enabled: false}, nil
+	}
+
+	var store CacheStore
+	var err error
+
+	switch cfg.Type {
+	case "sqlite":
+		store, err = NewSQLiteCache(cfg.Path)
+	case "memory":
+		store = NewMemoryCache(cfg.MaxSizeMB * 1024 * 1024)
+	default:
+		store = NewMemoryCache(cfg.MaxSizeMB * 1024 * 1024)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &Cache{
+		store:      store,
+		defaultTTL: cfg.DefaultTTL,
+		enabled:    true,
+	}, nil
+}
+
+// Get retrieves a cached result for the given URL
+func (c *Cache) Get(url string) (*FetchResult, bool) {
+	if !c.enabled || c.store == nil {
+		return nil, false
+	}
+
+	urlHash := hashURL(url)
+	entry, err := c.store.Get(urlHash)
+	if err != nil || entry == nil {
+		return nil, false
+	}
+
+	// Check if expired
+	if time.Now().After(entry.ExpiresAt) {
+		_ = c.store.Delete(urlHash)
+		return nil, false
+	}
+
+	// Reconstruct FetchResult
+	result := &FetchResult{
+		URL:         entry.URL,
+		ContentType: entry.ContentType,
+		RawHTML:     entry.RawContent,
+		CleanText:   entry.CleanText,
+		FetchedAt:   entry.FetchedAt,
+	}
+
+	// Decode code blocks
+	if len(entry.CodeBlocks) > 0 {
+		_ = json.Unmarshal(entry.CodeBlocks, &result.CodeBlocks)
+	}
+
+	return result, true
+}
+
+// Set stores a fetch result in the cache
+func (c *Cache) Set(url string, result *FetchResult) error {
+	return c.SetWithTTL(url, result, c.defaultTTL)
+}
+
+// SetWithTTL stores a fetch result with a specific TTL
+func (c *Cache) SetWithTTL(url string, result *FetchResult, ttl time.Duration) error {
+	if !c.enabled || c.store == nil {
+		return nil
+	}
+
+	// Encode code blocks
+	codeBlocksJSON, _ := json.Marshal(result.CodeBlocks)
+
+	entry := &CacheEntry{
+		ID:          uuid.New().String(),
+		URLHash:     hashURL(url),
+		URL:         url,
+		ContentType: result.ContentType,
+		RawContent:  result.RawHTML,
+		CleanText:   result.CleanText,
+		CodeBlocks:  codeBlocksJSON,
+		FetchedAt:   result.FetchedAt,
+		ExpiresAt:   time.Now().Add(ttl),
+		CreatedAt:   time.Now(),
+	}
+
+	return c.store.Set(entry)
+}
+
+// Delete removes a cached entry
+func (c *Cache) Delete(url string) error {
+	if !c.enabled || c.store == nil {
+		return nil
+	}
+	return c.store.Delete(hashURL(url))
+}
+
+// Cleanup removes expired entries
+func (c *Cache) Cleanup() error {
+	if !c.enabled || c.store == nil {
+		return nil
+	}
+	return c.store.Cleanup()
+}
+
+// Close closes the cache
+func (c *Cache) Close() error {
+	if c.store != nil {
+		return c.store.Close()
+	}
+	return nil
+}
+
+// hashURL creates a hash of the URL for use as cache key
+func hashURL(url string) string {
+	h := sha256.New()
+	h.Write([]byte(url))
+	return hex.EncodeToString(h.Sum(nil))[:16]
+}
+
+// MemoryCache implements an in-memory cache
+type MemoryCache struct {
+	data        map[string]*CacheEntry
+	maxSize     int64
+	currentSize int64
+	mu          sync.RWMutex
+}
+
+// NewMemoryCache creates a new in-memory cache
+func NewMemoryCache(maxSize int64) *MemoryCache {
+	return &MemoryCache{
+		data:    make(map[string]*CacheEntry),
+		maxSize: maxSize,
+	}
+}
+
+func (m *MemoryCache) Get(urlHash string) (*CacheEntry, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	entry, exists := m.data[urlHash]
+	if !exists {
+		return nil, nil
+	}
+	return entry, nil
+}
+
+func (m *MemoryCache) Set(entry *CacheEntry) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Estimate size
+	entrySize := int64(len(entry.RawContent) + len(entry.CleanText) + len(entry.CodeBlocks))
+
+	// Evict if necessary
+	for m.currentSize+entrySize > m.maxSize && len(m.data) > 0 {
+		// Simple eviction: remove oldest entry
+		var oldestKey string
+		var oldestTime time.Time
+		for key, e := range m.data {
+			if oldestKey == "" || e.CreatedAt.Before(oldestTime) {
+				oldestKey = key
+				oldestTime = e.CreatedAt
+			}
+		}
+		if oldestKey != "" {
+			oldEntry := m.data[oldestKey]
+			m.currentSize -= int64(len(oldEntry.RawContent) + len(oldEntry.CleanText) + len(oldEntry.CodeBlocks))
+			delete(m.data, oldestKey)
+		}
+	}
+
+	m.data[entry.URLHash] = entry
+	m.currentSize += entrySize
+	return nil
+}
+
+func (m *MemoryCache) Delete(urlHash string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if entry, exists := m.data[urlHash]; exists {
+		m.currentSize -= int64(len(entry.RawContent) + len(entry.CleanText) + len(entry.CodeBlocks))
+		delete(m.data, urlHash)
+	}
+	return nil
+}
+
+func (m *MemoryCache) Cleanup() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := time.Now()
+	for key, entry := range m.data {
+		if now.After(entry.ExpiresAt) {
+			m.currentSize -= int64(len(entry.RawContent) + len(entry.CleanText) + len(entry.CodeBlocks))
+			delete(m.data, key)
+		}
+	}
+	return nil
+}
+
+func (m *MemoryCache) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.data = nil
+	return nil
+}
+
+// SQLiteCache implements a SQLite-based cache
+type SQLiteCache struct {
+	db *sql.DB
+}
+
+// NewSQLiteCache creates a new SQLite cache
+func NewSQLiteCache(path string) (*SQLiteCache, error) {
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create table if not exists
+	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS webscrape_cache (
+			id TEXT PRIMARY KEY,
+			url_hash TEXT UNIQUE,
+			url TEXT,
+			content_type TEXT,
+			raw_content TEXT,
+			clean_text TEXT,
+			code_blocks TEXT,
+			metadata TEXT,
+			fetched_at DATETIME,
+			expires_at DATETIME,
+			created_at DATETIME
+		);
+		CREATE INDEX IF NOT EXISTS idx_cache_url_hash ON webscrape_cache(url_hash);
+		CREATE INDEX IF NOT EXISTS idx_cache_expires ON webscrape_cache(expires_at);
+	`)
+	if err != nil {
+		db.Close()
+		return nil, err
+	}
+
+	return &SQLiteCache{db: db}, nil
+}
+
+func (s *SQLiteCache) Get(urlHash string) (*CacheEntry, error) {
+	row := s.db.QueryRow(`
+		SELECT id, url_hash, url, content_type, raw_content, clean_text,
+		       code_blocks, metadata, fetched_at, expires_at, created_at
+		FROM webscrape_cache
+		WHERE url_hash = ?
+	`, urlHash)
+
+	var entry CacheEntry
+	var codeBlocks, metadata sql.NullString
+	var fetchedAt, expiresAt, createdAt string
+
+	err := row.Scan(
+		&entry.ID, &entry.URLHash, &entry.URL, &entry.ContentType,
+		&entry.RawContent, &entry.CleanText, &codeBlocks, &metadata,
+		&fetchedAt, &expiresAt, &createdAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	entry.FetchedAt, _ = time.Parse(time.RFC3339, fetchedAt)
+	entry.ExpiresAt, _ = time.Parse(time.RFC3339, expiresAt)
+	entry.CreatedAt, _ = time.Parse(time.RFC3339, createdAt)
+
+	if codeBlocks.Valid {
+		entry.CodeBlocks = []byte(codeBlocks.String)
+	}
+	if metadata.Valid {
+		entry.Metadata = []byte(metadata.String)
+	}
+
+	return &entry, nil
+}
+
+func (s *SQLiteCache) Set(entry *CacheEntry) error {
+	_, err := s.db.Exec(`
+		INSERT OR REPLACE INTO webscrape_cache
+		(id, url_hash, url, content_type, raw_content, clean_text,
+		 code_blocks, metadata, fetched_at, expires_at, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		entry.ID, entry.URLHash, entry.URL, entry.ContentType,
+		entry.RawContent, entry.CleanText,
+		string(entry.CodeBlocks), string(entry.Metadata),
+		entry.FetchedAt.Format(time.RFC3339),
+		entry.ExpiresAt.Format(time.RFC3339),
+		entry.CreatedAt.Format(time.RFC3339),
+	)
+	return err
+}
+
+func (s *SQLiteCache) Delete(urlHash string) error {
+	_, err := s.db.Exec("DELETE FROM webscrape_cache WHERE url_hash = ?", urlHash)
+	return err
+}
+
+func (s *SQLiteCache) Cleanup() error {
+	_, err := s.db.Exec("DELETE FROM webscrape_cache WHERE expires_at < ?", time.Now().Format(time.RFC3339))
+	return err
+}
+
+func (s *SQLiteCache) Close() error {
+	return s.db.Close()
+}

--- a/pkg/webscrape/cache_test.go
+++ b/pkg/webscrape/cache_test.go
@@ -1,0 +1,190 @@
+package webscrape
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMemoryCache(t *testing.T) {
+	cache := NewMemoryCache(1024 * 1024) // 1MB
+
+	t.Run("Set and Get", func(t *testing.T) {
+		entry := &CacheEntry{
+			ID:        "test-1",
+			URLHash:   "hash123",
+			URL:       "https://example.com",
+			CleanText: "test content",
+			ExpiresAt: time.Now().Add(1 * time.Hour),
+			CreatedAt: time.Now(),
+		}
+
+		err := cache.Set(entry)
+		if err != nil {
+			t.Fatalf("Set() error = %v", err)
+		}
+
+		got, err := cache.Get("hash123")
+		if err != nil {
+			t.Fatalf("Get() error = %v", err)
+		}
+		if got == nil {
+			t.Fatal("Get() returned nil")
+		}
+		if got.URL != entry.URL {
+			t.Errorf("URL = %q, want %q", got.URL, entry.URL)
+		}
+	})
+
+	t.Run("Get non-existent", func(t *testing.T) {
+		got, err := cache.Get("nonexistent")
+		if err != nil {
+			t.Fatalf("Get() error = %v", err)
+		}
+		if got != nil {
+			t.Error("Get() should return nil for non-existent key")
+		}
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		entry := &CacheEntry{
+			ID:        "test-2",
+			URLHash:   "hash456",
+			URL:       "https://example.com/2",
+			ExpiresAt: time.Now().Add(1 * time.Hour),
+			CreatedAt: time.Now(),
+		}
+
+		_ = cache.Set(entry)
+		err := cache.Delete("hash456")
+		if err != nil {
+			t.Fatalf("Delete() error = %v", err)
+		}
+
+		got, _ := cache.Get("hash456")
+		if got != nil {
+			t.Error("Entry should be deleted")
+		}
+	})
+
+	t.Run("Cleanup removes expired", func(t *testing.T) {
+		entry := &CacheEntry{
+			ID:        "test-3",
+			URLHash:   "hash789",
+			URL:       "https://example.com/3",
+			ExpiresAt: time.Now().Add(-1 * time.Hour), // Already expired
+			CreatedAt: time.Now(),
+		}
+
+		_ = cache.Set(entry)
+		err := cache.Cleanup()
+		if err != nil {
+			t.Fatalf("Cleanup() error = %v", err)
+		}
+
+		got, _ := cache.Get("hash789")
+		if got != nil {
+			t.Error("Expired entry should be cleaned up")
+		}
+	})
+}
+
+func TestCacheIntegration(t *testing.T) {
+	cfg := &CacheConfig{
+		Enabled:    true,
+		Type:       "memory",
+		DefaultTTL: 1 * time.Hour,
+		MaxSizeMB:  10,
+	}
+
+	cache, err := NewCache(cfg)
+	if err != nil {
+		t.Fatalf("NewCache() error = %v", err)
+	}
+	defer cache.Close()
+
+	t.Run("Set and Get FetchResult", func(t *testing.T) {
+		result := &FetchResult{
+			URL:         "https://example.com/test",
+			StatusCode:  200,
+			ContentType: "text/html",
+			CleanText:   "Hello World",
+			CodeBlocks: []CodeBlock{
+				{Language: "go", Code: "func main() {}"},
+			},
+			FetchedAt: time.Now(),
+		}
+
+		err := cache.Set("https://example.com/test", result)
+		if err != nil {
+			t.Fatalf("Set() error = %v", err)
+		}
+
+		got, found := cache.Get("https://example.com/test")
+		if !found {
+			t.Fatal("Get() should find cached result")
+		}
+		if got.URL != result.URL {
+			t.Errorf("URL = %q, want %q", got.URL, result.URL)
+		}
+		if got.CleanText != result.CleanText {
+			t.Errorf("CleanText = %q, want %q", got.CleanText, result.CleanText)
+		}
+		if len(got.CodeBlocks) != 1 {
+			t.Errorf("CodeBlocks count = %d, want 1", len(got.CodeBlocks))
+		}
+	})
+
+	t.Run("Get non-existent returns false", func(t *testing.T) {
+		_, found := cache.Get("https://nonexistent.com")
+		if found {
+			t.Error("Get() should return false for non-existent URL")
+		}
+	})
+}
+
+func TestCacheDisabled(t *testing.T) {
+	cfg := &CacheConfig{
+		Enabled: false,
+	}
+
+	cache, err := NewCache(cfg)
+	if err != nil {
+		t.Fatalf("NewCache() error = %v", err)
+	}
+
+	// Operations should not error on disabled cache
+	err = cache.Set("url", &FetchResult{})
+	if err != nil {
+		t.Errorf("Set() on disabled cache should not error: %v", err)
+	}
+
+	_, found := cache.Get("url")
+	if found {
+		t.Error("Get() on disabled cache should return false")
+	}
+
+	err = cache.Close()
+	if err != nil {
+		t.Errorf("Close() on disabled cache should not error: %v", err)
+	}
+}
+
+func TestHashURL(t *testing.T) {
+	// Same URL should produce same hash
+	hash1 := hashURL("https://example.com/test")
+	hash2 := hashURL("https://example.com/test")
+	if hash1 != hash2 {
+		t.Error("Same URL should produce same hash")
+	}
+
+	// Different URLs should produce different hashes
+	hash3 := hashURL("https://example.com/other")
+	if hash1 == hash3 {
+		t.Error("Different URLs should produce different hashes")
+	}
+
+	// Hash should be consistent length
+	if len(hash1) != 16 {
+		t.Errorf("Hash length = %d, want 16", len(hash1))
+	}
+}

--- a/pkg/webscrape/extractor.go
+++ b/pkg/webscrape/extractor.go
@@ -1,0 +1,437 @@
+package webscrape
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ContentExtractor extracts content from HTML
+type ContentExtractor interface {
+	Extract(html string, url string) (*ExtractedContent, error)
+	CanHandle(url string) bool
+}
+
+// ReadabilityExtractor extracts clean text using a readability-like algorithm
+type ReadabilityExtractor struct{}
+
+// NewReadabilityExtractor creates a new readability extractor
+func NewReadabilityExtractor() *ReadabilityExtractor {
+	return &ReadabilityExtractor{}
+}
+
+// CanHandle returns true - the readability extractor can handle any URL
+func (e *ReadabilityExtractor) CanHandle(url string) bool {
+	return true
+}
+
+// Extract extracts clean content from HTML
+func (e *ReadabilityExtractor) Extract(html string, url string) (*ExtractedContent, error) {
+	content := &ExtractedContent{
+		Metadata: make(map[string]string),
+	}
+
+	// Extract title
+	content.Title = extractTitle(html)
+
+	// Extract code blocks first (before stripping HTML)
+	content.CodeBlocks = extractCodeBlocks(html)
+
+	// Extract and clean main text
+	content.MainText = extractCleanText(html)
+
+	// Extract metadata
+	content.Metadata["description"] = extractMetaDescription(html)
+
+	return content, nil
+}
+
+// CodeExtractor specializes in extracting code from pages
+type CodeExtractor struct{}
+
+// NewCodeExtractor creates a new code extractor
+func NewCodeExtractor() *CodeExtractor {
+	return &CodeExtractor{}
+}
+
+// CanHandle returns true for technical sites
+func (e *CodeExtractor) CanHandle(url string) bool {
+	techDomains := []string{
+		"github.com", "gitlab.com", "stackoverflow.com",
+		"gist.github.com", "pastebin.com", "codepen.io",
+	}
+	for _, domain := range techDomains {
+		if strings.Contains(url, domain) {
+			return true
+		}
+	}
+	return false
+}
+
+// Extract extracts code-focused content from HTML
+func (e *CodeExtractor) Extract(html string, url string) (*ExtractedContent, error) {
+	content := &ExtractedContent{
+		Metadata: make(map[string]string),
+	}
+
+	content.Title = extractTitle(html)
+	content.CodeBlocks = extractCodeBlocks(html)
+	content.MainText = extractCleanText(html)
+
+	return content, nil
+}
+
+// Helper functions for HTML parsing (simple regex-based approach)
+// For production, consider using golang.org/x/net/html
+
+func extractTitle(html string) string {
+	// Try to find <title> tag
+	titleRe := regexp.MustCompile(`(?is)<title[^>]*>([^<]+)</title>`)
+	if matches := titleRe.FindStringSubmatch(html); len(matches) > 1 {
+		return cleanHTMLText(matches[1])
+	}
+
+	// Try to find <h1> tag
+	h1Re := regexp.MustCompile(`(?is)<h1[^>]*>([^<]+)</h1>`)
+	if matches := h1Re.FindStringSubmatch(html); len(matches) > 1 {
+		return cleanHTMLText(matches[1])
+	}
+
+	return ""
+}
+
+func extractMetaDescription(html string) string {
+	// Meta description
+	descRe := regexp.MustCompile(`(?is)<meta[^>]+name=["']description["'][^>]+content=["']([^"']+)["']`)
+	if matches := descRe.FindStringSubmatch(html); len(matches) > 1 {
+		return cleanHTMLText(matches[1])
+	}
+
+	// Try reverse order
+	descRe2 := regexp.MustCompile(`(?is)<meta[^>]+content=["']([^"']+)["'][^>]+name=["']description["']`)
+	if matches := descRe2.FindStringSubmatch(html); len(matches) > 1 {
+		return cleanHTMLText(matches[1])
+	}
+
+	return ""
+}
+
+func extractCodeBlocks(html string) []CodeBlock {
+	var blocks []CodeBlock
+
+	// Helper to extract language from tag attributes
+	langRe := regexp.MustCompile(`class=["'][^"']*(?:language-|lang-)([a-zA-Z0-9]+)`)
+
+	// Extract <pre><code> blocks - capture the code tag with its attributes
+	preCodeRe := regexp.MustCompile(`(?is)<pre[^>]*>\s*<code([^>]*)>(.*?)</code>\s*</pre>`)
+	matches := preCodeRe.FindAllStringSubmatch(html, -1)
+	for _, match := range matches {
+		attrs := match[1]
+		code := match[2]
+		lang := ""
+		if langMatch := langRe.FindStringSubmatch(attrs); len(langMatch) > 1 {
+			lang = langMatch[1]
+		}
+		blocks = append(blocks, CodeBlock{
+			Language: lang,
+			Code:     cleanCodeBlock(code),
+		})
+	}
+
+	// Extract standalone <pre> blocks - capture the pre tag with its attributes
+	preRe := regexp.MustCompile(`(?is)<pre([^>]*)>(.*?)</pre>`)
+	preMatches := preRe.FindAllStringSubmatch(html, -1)
+	for _, match := range preMatches {
+		attrs := match[1]
+		code := match[2]
+		// Skip if this looks like it was already captured as pre>code
+		if strings.Contains(code, "<code") {
+			continue
+		}
+		lang := ""
+		if langMatch := langRe.FindStringSubmatch(attrs); len(langMatch) > 1 {
+			lang = langMatch[1]
+		}
+		blocks = append(blocks, CodeBlock{
+			Language: lang,
+			Code:     cleanCodeBlock(code),
+		})
+	}
+
+	// Extract fenced code blocks from markdown content
+	fencedRe := regexp.MustCompile("(?m)```([a-zA-Z0-9]*)\n([^`]+)```")
+	fencedMatches := fencedRe.FindAllStringSubmatch(html, -1)
+	for _, match := range fencedMatches {
+		lang := ""
+		code := match[2]
+		if len(match) > 1 && match[1] != "" {
+			lang = match[1]
+		}
+		blocks = append(blocks, CodeBlock{
+			Language: lang,
+			Code:     strings.TrimSpace(code),
+		})
+	}
+
+	// Deduplicate blocks
+	seen := make(map[string]bool)
+	var unique []CodeBlock
+	for _, block := range blocks {
+		key := block.Language + ":" + block.Code
+		if !seen[key] && len(strings.TrimSpace(block.Code)) > 0 {
+			seen[key] = true
+			unique = append(unique, block)
+		}
+	}
+
+	return unique
+}
+
+func extractCleanText(html string) string {
+	// Remove script and style tags
+	scriptRe := regexp.MustCompile(`(?is)<script[^>]*>.*?</script>`)
+	html = scriptRe.ReplaceAllString(html, "")
+
+	styleRe := regexp.MustCompile(`(?is)<style[^>]*>.*?</style>`)
+	html = styleRe.ReplaceAllString(html, "")
+
+	// Remove HTML comments
+	commentRe := regexp.MustCompile(`(?s)<!--.*?-->`)
+	html = commentRe.ReplaceAllString(html, "")
+
+	// Remove navigation, header, footer, aside (each tag handled separately since Go RE2 doesn't support backreferences)
+	for _, tag := range []string{"nav", "header", "footer", "aside"} {
+		tagRe := regexp.MustCompile(`(?is)<` + tag + `[^>]*>.*?</` + tag + `>`)
+		html = tagRe.ReplaceAllString(html, "")
+	}
+
+	// Convert block elements to newlines
+	blockTags := []string{"div", "p", "br", "li", "h1", "h2", "h3", "h4", "h5", "h6", "tr", "td", "th"}
+	for _, tag := range blockTags {
+		re := regexp.MustCompile(`(?i)<` + tag + `[^>]*>`)
+		html = re.ReplaceAllString(html, "\n")
+		re = regexp.MustCompile(`(?i)</` + tag + `>`)
+		html = re.ReplaceAllString(html, "\n")
+	}
+
+	// Remove remaining HTML tags
+	tagRe := regexp.MustCompile(`<[^>]+>`)
+	html = tagRe.ReplaceAllString(html, "")
+
+	// Decode HTML entities
+	html = decodeHTMLEntities(html)
+
+	// Normalize whitespace
+	html = normalizeWhitespace(html)
+
+	return strings.TrimSpace(html)
+}
+
+func cleanHTMLText(text string) string {
+	// Remove HTML tags
+	tagRe := regexp.MustCompile(`<[^>]+>`)
+	text = tagRe.ReplaceAllString(text, "")
+
+	// Decode entities
+	text = decodeHTMLEntities(text)
+
+	// Normalize whitespace
+	return strings.TrimSpace(normalizeWhitespace(text))
+}
+
+func cleanCodeBlock(code string) string {
+	// Remove HTML tags from code
+	tagRe := regexp.MustCompile(`<[^>]+>`)
+	code = tagRe.ReplaceAllString(code, "")
+
+	// Decode HTML entities
+	code = decodeHTMLEntities(code)
+
+	return strings.TrimSpace(code)
+}
+
+func decodeHTMLEntities(text string) string {
+	entities := map[string]string{
+		"&amp;":    "&",
+		"&lt;":     "<",
+		"&gt;":     ">",
+		"&quot;":   `"`,
+		"&#39;":    "'",
+		"&apos;":   "'",
+		"&nbsp;":   " ",
+		"&copy;":   "(c)",
+		"&reg;":    "(R)",
+		"&trade;":  "(TM)",
+		"&ndash;":  "-",
+		"&mdash;":  "--",
+		"&lsquo;":  "'",
+		"&rsquo;":  "'",
+		"&ldquo;":  `"`,
+		"&rdquo;":  `"`,
+		"&bull;":   "*",
+		"&hellip;": "...",
+	}
+
+	for entity, replacement := range entities {
+		text = strings.ReplaceAll(text, entity, replacement)
+	}
+
+	// Handle numeric entities
+	numericRe := regexp.MustCompile(`&#(\d+);`)
+	text = numericRe.ReplaceAllStringFunc(text, func(s string) string {
+		matches := numericRe.FindStringSubmatch(s)
+		if len(matches) > 1 {
+			var code int
+			if _, err := parseIntFromString(matches[1]); err == nil {
+				code, _ = parseIntFromString(matches[1])
+				if code > 0 && code < 128 {
+					return string(rune(code))
+				}
+			}
+		}
+		return s
+	})
+
+	return text
+}
+
+func normalizeWhitespace(text string) string {
+	// Replace multiple newlines with double newline
+	multiNewline := regexp.MustCompile(`\n{3,}`)
+	text = multiNewline.ReplaceAllString(text, "\n\n")
+
+	// Replace multiple spaces with single space
+	multiSpace := regexp.MustCompile(`[ \t]+`)
+	text = multiSpace.ReplaceAllString(text, " ")
+
+	// Trim lines
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimSpace(line)
+	}
+	text = strings.Join(lines, "\n")
+
+	return text
+}
+
+func parseIntFromString(s string) (int, error) {
+	var result int
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			break
+		}
+		result = result*10 + int(c-'0')
+	}
+	return result, nil
+}
+
+// ExtractLinks extracts all links from HTML
+func ExtractLinks(html string) []Link {
+	var links []Link
+
+	linkRe := regexp.MustCompile(`(?is)<a[^>]+href=["']([^"']+)["'][^>]*>(.*?)</a>`)
+	matches := linkRe.FindAllStringSubmatch(html, -1)
+
+	for _, match := range matches {
+		if len(match) >= 3 {
+			url := match[1]
+			text := cleanHTMLText(match[2])
+
+			// Skip empty or fragment-only links
+			if url == "" || strings.HasPrefix(url, "#") {
+				continue
+			}
+
+			// Determine link type
+			linkType := ""
+			lowerURL := strings.ToLower(url)
+			if strings.Contains(lowerURL, "github.com") || strings.Contains(lowerURL, "gitlab.com") {
+				linkType = "source"
+			} else if strings.Contains(lowerURL, "docs") || strings.Contains(lowerURL, "documentation") {
+				linkType = "documentation"
+			}
+
+			links = append(links, Link{
+				Text: text,
+				URL:  url,
+				Type: linkType,
+			})
+		}
+	}
+
+	return links
+}
+
+// DetectLanguage attempts to detect the programming language of a code block
+func DetectLanguage(code string) string {
+	// Simple heuristic-based detection
+	code = strings.TrimSpace(code)
+
+	// Go
+	if strings.Contains(code, "func ") && strings.Contains(code, "package ") {
+		return "go"
+	}
+	if strings.HasPrefix(code, "package ") {
+		return "go"
+	}
+
+	// Python
+	if strings.HasPrefix(code, "def ") || strings.HasPrefix(code, "class ") {
+		return "python"
+	}
+	if strings.Contains(code, "import ") && strings.Contains(code, ":") {
+		return "python"
+	}
+
+	// TypeScript (check first as it's more specific)
+	if strings.Contains(code, ": ") && (strings.Contains(code, "interface ") || strings.Contains(code, "type ")) {
+		return "typescript"
+	}
+
+	// JavaScript
+	if strings.Contains(code, "function ") || strings.Contains(code, "const ") || strings.Contains(code, "let ") {
+		return "javascript"
+	}
+
+	// Rust
+	if strings.Contains(code, "fn ") && strings.Contains(code, "let ") {
+		return "rust"
+	}
+
+	// Java
+	if strings.Contains(code, "public class ") || strings.Contains(code, "private ") {
+		return "java"
+	}
+
+	// HTML
+	if strings.Contains(code, "<!DOCTYPE") || strings.Contains(code, "<html") {
+		return "html"
+	}
+
+	// CSS
+	if strings.Contains(code, "{") && (strings.Contains(code, "color:") || strings.Contains(code, "margin:") || strings.Contains(code, "padding:")) {
+		return "css"
+	}
+
+	// Shell/Bash
+	if strings.HasPrefix(code, "#!/bin/") || strings.HasPrefix(code, "$ ") {
+		return "bash"
+	}
+
+	// JSON
+	if (strings.HasPrefix(code, "{") && strings.HasSuffix(code, "}")) ||
+		(strings.HasPrefix(code, "[") && strings.HasSuffix(code, "]")) {
+		return "json"
+	}
+
+	// YAML
+	if strings.Contains(code, "---") && strings.Contains(code, ":") {
+		return "yaml"
+	}
+
+	// SQL
+	if strings.Contains(strings.ToUpper(code), "SELECT ") || strings.Contains(strings.ToUpper(code), "CREATE TABLE") {
+		return "sql"
+	}
+
+	return ""
+}

--- a/pkg/webscrape/extractor_test.go
+++ b/pkg/webscrape/extractor_test.go
@@ -1,0 +1,291 @@
+package webscrape
+
+import (
+	"testing"
+)
+
+func TestExtractTitle(t *testing.T) {
+	tests := []struct {
+		name     string
+		html     string
+		expected string
+	}{
+		{
+			name:     "extracts title tag",
+			html:     `<html><head><title>Test Title</title></head><body></body></html>`,
+			expected: "Test Title",
+		},
+		{
+			name:     "extracts h1 when no title",
+			html:     `<html><body><h1>Heading One</h1></body></html>`,
+			expected: "Heading One",
+		},
+		{
+			name:     "handles empty html",
+			html:     "",
+			expected: "",
+		},
+		{
+			name:     "decodes HTML entities in title",
+			html:     `<title>Test &amp; Title</title>`,
+			expected: "Test & Title",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractTitle(tt.html)
+			if result != tt.expected {
+				t.Errorf("extractTitle() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExtractCodeBlocks(t *testing.T) {
+	tests := []struct {
+		name          string
+		html          string
+		expectedCount int
+		checkFirst    *CodeBlock
+	}{
+		{
+			name:          "extracts pre>code blocks",
+			html:          `<pre><code class="language-go">func main() {}</code></pre>`,
+			expectedCount: 1,
+			checkFirst: &CodeBlock{
+				Language: "go",
+				Code:     "func main() {}",
+			},
+		},
+		{
+			name:          "extracts standalone pre blocks",
+			html:          `<pre>echo "hello"</pre>`,
+			expectedCount: 1,
+			checkFirst: &CodeBlock{
+				Language: "",
+				Code:     `echo "hello"`,
+			},
+		},
+		{
+			name:          "handles multiple code blocks",
+			html:          `<pre><code>code1</code></pre><pre><code>code2</code></pre>`,
+			expectedCount: 2,
+		},
+		{
+			name:          "handles empty html",
+			html:          "",
+			expectedCount: 0,
+		},
+		{
+			name:          "extracts fenced markdown code blocks",
+			html:          "```python\nprint('hello')\n```",
+			expectedCount: 1,
+			checkFirst: &CodeBlock{
+				Language: "python",
+				Code:     "print('hello')",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractCodeBlocks(tt.html)
+			if len(result) != tt.expectedCount {
+				t.Errorf("extractCodeBlocks() returned %d blocks, want %d", len(result), tt.expectedCount)
+			}
+			if tt.checkFirst != nil && len(result) > 0 {
+				if result[0].Language != tt.checkFirst.Language {
+					t.Errorf("first block Language = %q, want %q", result[0].Language, tt.checkFirst.Language)
+				}
+				if result[0].Code != tt.checkFirst.Code {
+					t.Errorf("first block Code = %q, want %q", result[0].Code, tt.checkFirst.Code)
+				}
+			}
+		})
+	}
+}
+
+func TestExtractCleanText(t *testing.T) {
+	tests := []struct {
+		name     string
+		html     string
+		contains []string
+		excludes []string
+	}{
+		{
+			name:     "removes script tags",
+			html:     `<p>Hello</p><script>alert('bad')</script><p>World</p>`,
+			contains: []string{"Hello", "World"},
+			excludes: []string{"script", "alert"},
+		},
+		{
+			name:     "removes style tags",
+			html:     `<p>Hello</p><style>.foo { color: red; }</style><p>World</p>`,
+			contains: []string{"Hello", "World"},
+			excludes: []string{"style", "color", ".foo"},
+		},
+		{
+			name:     "converts paragraphs to newlines",
+			html:     `<p>Para 1</p><p>Para 2</p>`,
+			contains: []string{"Para 1", "Para 2"},
+		},
+		{
+			name:     "decodes HTML entities",
+			html:     `<p>Test &amp; entities &lt;here&gt;</p>`,
+			contains: []string{"Test & entities <here>"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractCleanText(tt.html)
+			for _, c := range tt.contains {
+				if !containsString(result, c) {
+					t.Errorf("extractCleanText() should contain %q, got %q", c, result)
+				}
+			}
+			for _, e := range tt.excludes {
+				if containsString(result, e) {
+					t.Errorf("extractCleanText() should not contain %q, got %q", e, result)
+				}
+			}
+		})
+	}
+}
+
+func TestDetectLanguage(t *testing.T) {
+	tests := []struct {
+		name     string
+		code     string
+		expected string
+	}{
+		{
+			name:     "detects Go",
+			code:     "package main\n\nfunc main() {}",
+			expected: "go",
+		},
+		{
+			name:     "detects Python def",
+			code:     "def hello():\n    print('hello')",
+			expected: "python",
+		},
+		{
+			name:     "detects Python class",
+			code:     "class Foo:\n    pass",
+			expected: "python",
+		},
+		{
+			name:     "detects JavaScript",
+			code:     "function hello() { return 'world'; }",
+			expected: "javascript",
+		},
+		{
+			name:     "detects TypeScript",
+			code:     "interface Foo { bar: string; }",
+			expected: "typescript",
+		},
+		{
+			name:     "detects JSON",
+			code:     `{"key": "value"}`,
+			expected: "json",
+		},
+		{
+			name:     "detects SQL",
+			code:     "SELECT * FROM users WHERE id = 1",
+			expected: "sql",
+		},
+		{
+			name:     "detects Bash",
+			code:     "#!/bin/bash\necho hello",
+			expected: "bash",
+		},
+		{
+			name:     "returns empty for unknown",
+			code:     "random text here",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := DetectLanguage(tt.code)
+			if result != tt.expected {
+				t.Errorf("DetectLanguage() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestReadabilityExtractor(t *testing.T) {
+	extractor := NewReadabilityExtractor()
+
+	t.Run("CanHandle returns true for any URL", func(t *testing.T) {
+		if !extractor.CanHandle("https://example.com") {
+			t.Error("CanHandle should return true for any URL")
+		}
+	})
+
+	t.Run("Extract returns content", func(t *testing.T) {
+		html := `
+			<html>
+			<head><title>Test Page</title></head>
+			<body>
+				<h1>Main Content</h1>
+				<p>This is the body text.</p>
+				<pre><code class="language-go">func main() {}</code></pre>
+			</body>
+			</html>
+		`
+		content, err := extractor.Extract(html, "https://example.com")
+		if err != nil {
+			t.Fatalf("Extract() error = %v", err)
+		}
+		if content.Title != "Test Page" {
+			t.Errorf("Title = %q, want %q", content.Title, "Test Page")
+		}
+		if len(content.CodeBlocks) != 1 {
+			t.Errorf("CodeBlocks count = %d, want 1", len(content.CodeBlocks))
+		}
+		if !containsString(content.MainText, "Main Content") {
+			t.Error("MainText should contain 'Main Content'")
+		}
+	})
+}
+
+func TestCodeExtractor(t *testing.T) {
+	extractor := NewCodeExtractor()
+
+	t.Run("CanHandle returns true for tech sites", func(t *testing.T) {
+		techURLs := []string{
+			"https://github.com/foo/bar",
+			"https://gitlab.com/foo/bar",
+			"https://stackoverflow.com/questions/123",
+			"https://gist.github.com/foo/123",
+		}
+		for _, url := range techURLs {
+			if !extractor.CanHandle(url) {
+				t.Errorf("CanHandle(%q) should return true", url)
+			}
+		}
+	})
+
+	t.Run("CanHandle returns false for non-tech sites", func(t *testing.T) {
+		if extractor.CanHandle("https://example.com") {
+			t.Error("CanHandle(example.com) should return false")
+		}
+	})
+}
+
+func containsString(s, substr string) bool {
+	return len(s) > 0 && len(substr) > 0 && (s == substr || len(s) > len(substr) && (s[:len(substr)] == substr || s[len(s)-len(substr):] == substr || containsSubstr(s, substr)))
+}
+
+func containsSubstr(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/webscrape/fetcher.go
+++ b/pkg/webscrape/fetcher.go
@@ -1,0 +1,396 @@
+package webscrape
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Fetcher is the main interface for fetching web content
+type Fetcher interface {
+	Fetch(ctx context.Context, url string, opts *FetchOptions) (*FetchResult, error)
+}
+
+// HTTPFetcher implements Fetcher using HTTP
+type HTTPFetcher struct {
+	client      *http.Client
+	rateLimiter *RateLimiter
+	cache       *Cache
+	extractor   *ReadabilityExtractor
+}
+
+// FetcherConfig configures the HTTP fetcher
+type FetcherConfig struct {
+	UserAgent    string
+	Timeout      time.Duration
+	MaxRedirects int
+	Cache        *CacheConfig
+	RateLimits   map[string]float64
+}
+
+// DefaultFetcherConfig returns default fetcher configuration
+func DefaultFetcherConfig() *FetcherConfig {
+	return &FetcherConfig{
+		UserAgent:    "PedroCLI/1.0 (Web Scraping Tool)",
+		Timeout:      30 * time.Second,
+		MaxRedirects: 10,
+		Cache:        DefaultCacheConfig(),
+		RateLimits:   DefaultRateLimits,
+	}
+}
+
+// NewHTTPFetcher creates a new HTTP fetcher
+func NewHTTPFetcher(cfg *FetcherConfig) (*HTTPFetcher, error) {
+	if cfg == nil {
+		cfg = DefaultFetcherConfig()
+	}
+
+	// Create HTTP client with custom transport
+	transport := &http.Transport{
+		MaxIdleConns:       100,
+		IdleConnTimeout:    90 * time.Second,
+		DisableCompression: false,
+		DisableKeepAlives:  false,
+	}
+
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   cfg.Timeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= cfg.MaxRedirects {
+				return fmt.Errorf("too many redirects (max %d)", cfg.MaxRedirects)
+			}
+			return nil
+		},
+	}
+
+	// Create rate limiter
+	rateLimiter := NewRateLimiter()
+	for domain, rate := range cfg.RateLimits {
+		if domain != "default" {
+			rateLimiter.SetLimit(domain, rate)
+		}
+	}
+
+	// Create cache
+	var cache *Cache
+	if cfg.Cache != nil && cfg.Cache.Enabled {
+		var err error
+		cache, err = NewCache(cfg.Cache)
+		if err != nil {
+			// Log but don't fail - caching is optional
+			cache = nil
+		}
+	}
+
+	return &HTTPFetcher{
+		client:      client,
+		rateLimiter: rateLimiter,
+		cache:       cache,
+		extractor:   NewReadabilityExtractor(),
+	}, nil
+}
+
+// Fetch fetches content from a URL
+func (f *HTTPFetcher) Fetch(ctx context.Context, rawURL string, opts *FetchOptions) (*FetchResult, error) {
+	if opts == nil {
+		opts = DefaultFetchOptions()
+	}
+
+	// Validate URL
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
+		return nil, &ScrapeError{
+			Type:       ErrInvalidURL,
+			Message:    fmt.Sprintf("invalid URL: %s", rawURL),
+			Suggestion: "Please provide a valid URL with scheme (http:// or https://)",
+		}
+	}
+
+	// Normalize URL scheme
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return nil, &ScrapeError{
+			Type:       ErrInvalidURL,
+			Message:    fmt.Sprintf("unsupported URL scheme: %s", parsedURL.Scheme),
+			Suggestion: "Use http:// or https:// URLs",
+		}
+	}
+
+	// Check cache first
+	if f.cache != nil {
+		if cached, found := f.cache.Get(rawURL); found {
+			return cached, nil
+		}
+	}
+
+	// Wait for rate limit
+	if err := f.rateLimiter.WaitForURL(ctx, rawURL); err != nil {
+		return nil, &ScrapeError{
+			Type:       ErrTimeout,
+			Message:    "rate limit wait cancelled",
+			Retryable:  true,
+			Suggestion: "Try again in a few seconds",
+		}
+	}
+
+	// Create request
+	req, err := http.NewRequestWithContext(ctx, "GET", rawURL, nil)
+	if err != nil {
+		return nil, &ScrapeError{
+			Type:      ErrNetwork,
+			Message:   fmt.Sprintf("failed to create request: %v", err),
+			Retryable: true,
+		}
+	}
+
+	// Set headers
+	req.Header.Set("User-Agent", opts.UserAgent)
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+	req.Header.Set("Accept-Language", "en-US,en;q=0.5")
+
+	for key, value := range opts.Headers {
+		req.Header.Set(key, value)
+	}
+
+	// Execute request
+	resp, err := f.client.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, &ScrapeError{
+				Type:       ErrTimeout,
+				Message:    "request cancelled or timed out",
+				Retryable:  true,
+				Suggestion: "Try again with a longer timeout",
+			}
+		}
+		return nil, &ScrapeError{
+			Type:       ErrNetwork,
+			Message:    fmt.Sprintf("network error: %v", err),
+			Retryable:  true,
+			Suggestion: "Check network connectivity and try again",
+		}
+	}
+	defer resp.Body.Close()
+
+	// Handle HTTP errors
+	if resp.StatusCode >= 400 {
+		return nil, f.handleHTTPError(resp.StatusCode, rawURL)
+	}
+
+	// Read body with size limit
+	limitedReader := io.LimitReader(resp.Body, opts.MaxSize)
+	body, err := io.ReadAll(limitedReader)
+	if err != nil {
+		return nil, &ScrapeError{
+			Type:      ErrNetwork,
+			Message:   fmt.Sprintf("failed to read response: %v", err),
+			Retryable: true,
+		}
+	}
+
+	// Build result
+	result := &FetchResult{
+		URL:         resp.Request.URL.String(), // Final URL after redirects
+		StatusCode:  resp.StatusCode,
+		ContentType: resp.Header.Get("Content-Type"),
+		RawHTML:     string(body),
+		FetchedAt:   time.Now(),
+	}
+
+	// Extract content if requested
+	if opts.ExtractContent || opts.ExtractCode {
+		extracted, err := f.extractor.Extract(result.RawHTML, result.URL)
+		if err == nil {
+			result.Title = extracted.Title
+			result.CleanText = extracted.MainText
+			if opts.ExtractCode {
+				result.CodeBlocks = extracted.CodeBlocks
+			}
+			if desc, ok := extracted.Metadata["description"]; ok {
+				result.Description = desc
+			}
+		}
+	}
+
+	// Extract links
+	result.Links = ExtractLinks(result.RawHTML)
+
+	// Cache the result
+	if f.cache != nil {
+		_ = f.cache.Set(rawURL, result)
+	}
+
+	return result, nil
+}
+
+// handleHTTPError converts HTTP status codes to ScrapeError
+func (f *HTTPFetcher) handleHTTPError(statusCode int, url string) *ScrapeError {
+	switch {
+	case statusCode == 404:
+		return &ScrapeError{
+			Type:       ErrNotFound,
+			Message:    fmt.Sprintf("page not found: %s", url),
+			StatusCode: statusCode,
+			Retryable:  false,
+			Suggestion: "Verify the URL is correct",
+		}
+	case statusCode == 401 || statusCode == 403:
+		return &ScrapeError{
+			Type:       ErrAccessDenied,
+			Message:    fmt.Sprintf("access denied: %s", url),
+			StatusCode: statusCode,
+			Retryable:  false,
+			Suggestion: "This resource may require authentication or be private",
+		}
+	case statusCode == 429:
+		return &ScrapeError{
+			Type:       ErrRateLimited,
+			Message:    fmt.Sprintf("rate limited: %s", url),
+			StatusCode: statusCode,
+			Retryable:  true,
+			Suggestion: "Wait a few seconds and try again",
+		}
+	case statusCode >= 500:
+		return &ScrapeError{
+			Type:       ErrNetwork,
+			Message:    fmt.Sprintf("server error (%d): %s", statusCode, url),
+			StatusCode: statusCode,
+			Retryable:  true,
+			Suggestion: "The server may be temporarily unavailable. Try again later.",
+		}
+	default:
+		return &ScrapeError{
+			Type:       ErrNetwork,
+			Message:    fmt.Sprintf("HTTP error %d: %s", statusCode, url),
+			StatusCode: statusCode,
+			Retryable:  statusCode < 400,
+		}
+	}
+}
+
+// FetchRaw fetches raw content without any processing
+func (f *HTTPFetcher) FetchRaw(ctx context.Context, rawURL string, opts *FetchOptions) ([]byte, error) {
+	if opts == nil {
+		opts = DefaultFetchOptions()
+	}
+
+	// Validate URL
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
+		return nil, &ScrapeError{
+			Type:    ErrInvalidURL,
+			Message: fmt.Sprintf("invalid URL: %s", rawURL),
+		}
+	}
+
+	// Wait for rate limit
+	if err := f.rateLimiter.WaitForURL(ctx, rawURL); err != nil {
+		return nil, err
+	}
+
+	// Create request
+	req, err := http.NewRequestWithContext(ctx, "GET", rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("User-Agent", opts.UserAgent)
+	for key, value := range opts.Headers {
+		req.Header.Set(key, value)
+	}
+
+	// Execute request
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return nil, f.handleHTTPError(resp.StatusCode, rawURL)
+	}
+
+	// Read body with size limit
+	limitedReader := io.LimitReader(resp.Body, opts.MaxSize)
+	return io.ReadAll(limitedReader)
+}
+
+// Close cleans up resources
+func (f *HTTPFetcher) Close() error {
+	if f.cache != nil {
+		return f.cache.Close()
+	}
+	return nil
+}
+
+// FormatForAgent converts a FetchResult to an AgentResponse
+func FormatForAgent(result *FetchResult) *AgentResponse {
+	resp := &AgentResponse{
+		Success:     true,
+		Source:      result.URL,
+		ContentType: detectContentType(result),
+		Summary:     generateSummary(result),
+		Content:     result.CleanText,
+		Metadata:    make(map[string]interface{}),
+	}
+
+	// Format code blocks
+	for _, block := range result.CodeBlocks {
+		resp.CodeBlocks = append(resp.CodeBlocks, AgentCodeBlock{
+			Language:    block.Language,
+			Code:        block.Code,
+			Description: block.Context,
+		})
+	}
+
+	// Format links
+	for _, link := range result.Links {
+		resp.Links = append(resp.Links, AgentLink(link))
+	}
+
+	resp.Metadata["title"] = result.Title
+	resp.Metadata["fetched_at"] = result.FetchedAt
+
+	return resp
+}
+
+func detectContentType(result *FetchResult) string {
+	if len(result.CodeBlocks) > 0 {
+		if len(result.CleanText) > len(result.CodeBlocks[0].Code)*2 {
+			return "mixed"
+		}
+		return "code"
+	}
+	return "text"
+}
+
+func generateSummary(result *FetchResult) string {
+	var parts []string
+
+	if result.Title != "" {
+		parts = append(parts, result.Title)
+	}
+
+	if result.Description != "" {
+		parts = append(parts, result.Description)
+	}
+
+	if len(result.CodeBlocks) > 0 {
+		parts = append(parts, fmt.Sprintf("Contains %d code block(s)", len(result.CodeBlocks)))
+	}
+
+	if len(parts) == 0 {
+		// Generate from clean text
+		text := result.CleanText
+		if len(text) > 200 {
+			text = text[:200] + "..."
+		}
+		return strings.TrimSpace(text)
+	}
+
+	return strings.Join(parts, " - ")
+}

--- a/pkg/webscrape/handlers/github.go
+++ b/pkg/webscrape/handlers/github.go
@@ -1,0 +1,602 @@
+// Package handlers provides site-specific web scraping handlers
+package handlers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/soypete/pedrocli/pkg/webscrape"
+)
+
+// GitHubHandler handles GitHub-specific fetching operations
+type GitHubHandler struct {
+	apiToken    string
+	httpClient  *http.Client
+	rateLimiter *webscrape.RateLimiter
+}
+
+// GitHubConfig configures the GitHub handler
+type GitHubConfig struct {
+	APIToken string // Optional, for higher rate limits
+	Timeout  time.Duration
+}
+
+// NewGitHubHandler creates a new GitHub handler
+func NewGitHubHandler(cfg *GitHubConfig) *GitHubHandler {
+	if cfg == nil {
+		cfg = &GitHubConfig{}
+	}
+
+	timeout := cfg.Timeout
+	if timeout == 0 {
+		timeout = 30 * time.Second
+	}
+
+	h := &GitHubHandler{
+		apiToken: cfg.APIToken,
+		httpClient: &http.Client{
+			Timeout: timeout,
+		},
+		rateLimiter: webscrape.NewRateLimiter(),
+	}
+
+	// Set appropriate rate limits based on authentication
+	if cfg.APIToken != "" {
+		h.rateLimiter.SetLimit("api.github.com", 30)
+	} else {
+		h.rateLimiter.SetLimit("api.github.com", 10)
+	}
+
+	return h
+}
+
+// FetchFile fetches a file from a GitHub repository
+func (g *GitHubHandler) FetchFile(ctx context.Context, owner, repo, filePath, ref string) (*webscrape.GitHubFile, error) {
+	if ref == "" {
+		ref = "main"
+	}
+
+	// Use Contents API
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/contents/%s?ref=%s",
+		url.PathEscape(owner),
+		url.PathEscape(repo),
+		filePath,
+		url.QueryEscape(ref))
+
+	var content struct {
+		Name        string `json:"name"`
+		Path        string `json:"path"`
+		SHA         string `json:"sha"`
+		Size        int    `json:"size"`
+		URL         string `json:"url"`
+		HTMLURL     string `json:"html_url"`
+		DownloadURL string `json:"download_url"`
+		Type        string `json:"type"`
+		Content     string `json:"content"`
+		Encoding    string `json:"encoding"`
+	}
+
+	if err := g.doAPIRequest(ctx, apiURL, &content); err != nil {
+		return nil, err
+	}
+
+	if content.Type != "file" {
+		return nil, &webscrape.ScrapeError{
+			Type:       webscrape.ErrNotFound,
+			Message:    fmt.Sprintf("%s is not a file (type: %s)", filePath, content.Type),
+			Suggestion: "Use FetchDirectory for directories",
+		}
+	}
+
+	// Decode content
+	var fileContent string
+	if content.Encoding == "base64" {
+		decoded, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(content.Content, "\n", ""))
+		if err != nil {
+			return nil, &webscrape.ScrapeError{
+				Type:    webscrape.ErrParseFailure,
+				Message: fmt.Sprintf("failed to decode file content: %v", err),
+			}
+		}
+		fileContent = string(decoded)
+	} else if content.DownloadURL != "" {
+		// Fetch raw content
+		raw, err := g.fetchRaw(ctx, content.DownloadURL)
+		if err != nil {
+			return nil, err
+		}
+		fileContent = string(raw)
+	}
+
+	// Detect language from extension
+	language := detectLanguageFromPath(content.Path)
+
+	return &webscrape.GitHubFile{
+		Path:     content.Path,
+		Content:  fileContent,
+		Language: language,
+		Size:     content.Size,
+		SHA:      content.SHA,
+		URL:      content.HTMLURL,
+	}, nil
+}
+
+// FetchREADME fetches the README from a GitHub repository
+func (g *GitHubHandler) FetchREADME(ctx context.Context, owner, repo string) (*webscrape.GitHubFile, error) {
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/readme",
+		url.PathEscape(owner),
+		url.PathEscape(repo))
+
+	var content struct {
+		Name        string `json:"name"`
+		Path        string `json:"path"`
+		SHA         string `json:"sha"`
+		Size        int    `json:"size"`
+		URL         string `json:"url"`
+		HTMLURL     string `json:"html_url"`
+		DownloadURL string `json:"download_url"`
+		Content     string `json:"content"`
+		Encoding    string `json:"encoding"`
+	}
+
+	if err := g.doAPIRequest(ctx, apiURL, &content); err != nil {
+		return nil, err
+	}
+
+	// Decode content
+	var fileContent string
+	if content.Encoding == "base64" {
+		decoded, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(content.Content, "\n", ""))
+		if err != nil {
+			return nil, &webscrape.ScrapeError{
+				Type:    webscrape.ErrParseFailure,
+				Message: fmt.Sprintf("failed to decode README content: %v", err),
+			}
+		}
+		fileContent = string(decoded)
+	} else if content.DownloadURL != "" {
+		raw, err := g.fetchRaw(ctx, content.DownloadURL)
+		if err != nil {
+			return nil, err
+		}
+		fileContent = string(raw)
+	}
+
+	return &webscrape.GitHubFile{
+		Path:     content.Path,
+		Content:  fileContent,
+		Language: "markdown",
+		Size:     content.Size,
+		SHA:      content.SHA,
+		URL:      content.HTMLURL,
+	}, nil
+}
+
+// FetchDirectory lists files in a GitHub repository directory
+func (g *GitHubHandler) FetchDirectory(ctx context.Context, owner, repo, dirPath, ref string) ([]webscrape.GitHubEntry, error) {
+	if ref == "" {
+		ref = "main"
+	}
+
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/contents/%s?ref=%s",
+		url.PathEscape(owner),
+		url.PathEscape(repo),
+		dirPath,
+		url.QueryEscape(ref))
+
+	var contents []struct {
+		Name        string `json:"name"`
+		Path        string `json:"path"`
+		SHA         string `json:"sha"`
+		Size        int    `json:"size"`
+		URL         string `json:"url"`
+		HTMLURL     string `json:"html_url"`
+		DownloadURL string `json:"download_url"`
+		Type        string `json:"type"`
+	}
+
+	if err := g.doAPIRequest(ctx, apiURL, &contents); err != nil {
+		return nil, err
+	}
+
+	var entries []webscrape.GitHubEntry
+	for _, c := range contents {
+		entries = append(entries, webscrape.GitHubEntry{
+			Name: c.Name,
+			Path: c.Path,
+			Type: c.Type,
+			Size: c.Size,
+			SHA:  c.SHA,
+			URL:  c.HTMLURL,
+		})
+	}
+
+	return entries, nil
+}
+
+// SearchCode searches for code on GitHub
+func (g *GitHubHandler) SearchCode(ctx context.Context, query string, opts *webscrape.GitHubSearchOpts) ([]webscrape.GitHubSearchResult, error) {
+	if opts == nil {
+		opts = &webscrape.GitHubSearchOpts{}
+	}
+
+	// Build search query
+	q := query
+	if opts.Language != "" {
+		q += " language:" + opts.Language
+	}
+	if opts.Repo != "" {
+		q += " repo:" + opts.Repo
+	}
+	if opts.Path != "" {
+		q += " path:" + opts.Path
+	}
+
+	perPage := opts.PerPage
+	if perPage == 0 {
+		perPage = 30
+	}
+
+	apiURL := fmt.Sprintf("https://api.github.com/search/code?q=%s&per_page=%d",
+		url.QueryEscape(q),
+		perPage)
+
+	var response struct {
+		TotalCount int `json:"total_count"`
+		Items      []struct {
+			Name       string `json:"name"`
+			Path       string `json:"path"`
+			SHA        string `json:"sha"`
+			URL        string `json:"url"`
+			HTMLURL    string `json:"html_url"`
+			Repository struct {
+				FullName string `json:"full_name"`
+			} `json:"repository"`
+			TextMatches []struct {
+				Fragment string `json:"fragment"`
+			} `json:"text_matches"`
+		} `json:"items"`
+	}
+
+	// Need to request text matches
+	req, err := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	g.setHeaders(req)
+	req.Header.Set("Accept", "application/vnd.github.text-match+json")
+
+	if err := g.rateLimiter.Wait(ctx, "api.github.com"); err != nil {
+		return nil, err
+	}
+
+	resp, err := g.httpClient.Do(req)
+	if err != nil {
+		return nil, &webscrape.ScrapeError{
+			Type:      webscrape.ErrNetwork,
+			Message:   fmt.Sprintf("search request failed: %v", err),
+			Retryable: true,
+		}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, g.handleHTTPError(resp.StatusCode)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, &webscrape.ScrapeError{
+			Type:    webscrape.ErrParseFailure,
+			Message: fmt.Sprintf("failed to parse search response: %v", err),
+		}
+	}
+
+	var results []webscrape.GitHubSearchResult
+	for _, item := range response.Items {
+		fragment := ""
+		if len(item.TextMatches) > 0 {
+			fragment = item.TextMatches[0].Fragment
+		}
+
+		results = append(results, webscrape.GitHubSearchResult{
+			Repository: item.Repository.FullName,
+			Path:       item.Path,
+			SHA:        item.SHA,
+			URL:        item.HTMLURL,
+			Fragment:   fragment,
+		})
+	}
+
+	return results, nil
+}
+
+// FetchGist fetches a GitHub gist
+func (g *GitHubHandler) FetchGist(ctx context.Context, gistID string) (*webscrape.Gist, error) {
+	apiURL := fmt.Sprintf("https://api.github.com/gists/%s", url.PathEscape(gistID))
+
+	var response struct {
+		ID          string `json:"id"`
+		Description string `json:"description"`
+		Public      bool   `json:"public"`
+		HTMLURL     string `json:"html_url"`
+		CreatedAt   string `json:"created_at"`
+		Files       map[string]struct {
+			Filename string `json:"filename"`
+			Content  string `json:"content"`
+			Language string `json:"language"`
+			Size     int    `json:"size"`
+		} `json:"files"`
+	}
+
+	if err := g.doAPIRequest(ctx, apiURL, &response); err != nil {
+		return nil, err
+	}
+
+	files := make(map[string]string)
+	for filename, file := range response.Files {
+		files[filename] = file.Content
+	}
+
+	createdAt, _ := time.Parse(time.RFC3339, response.CreatedAt)
+
+	return &webscrape.Gist{
+		ID:          response.ID,
+		Description: response.Description,
+		Public:      response.Public,
+		Files:       files,
+		URL:         response.HTMLURL,
+		CreatedAt:   createdAt,
+	}, nil
+}
+
+// FetchRawURL fetches content from a raw.githubusercontent.com URL
+func (g *GitHubHandler) FetchRawURL(ctx context.Context, rawURL string) (string, error) {
+	if !strings.Contains(rawURL, "raw.githubusercontent.com") {
+		return "", &webscrape.ScrapeError{
+			Type:       webscrape.ErrInvalidURL,
+			Message:    "not a raw.githubusercontent.com URL",
+			Suggestion: "Use FetchFile for regular GitHub URLs",
+		}
+	}
+
+	content, err := g.fetchRaw(ctx, rawURL)
+	if err != nil {
+		return "", err
+	}
+
+	return string(content), nil
+}
+
+// doAPIRequest performs an API request and decodes the JSON response
+func (g *GitHubHandler) doAPIRequest(ctx context.Context, apiURL string, result interface{}) error {
+	req, err := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
+	if err != nil {
+		return &webscrape.ScrapeError{
+			Type:    webscrape.ErrNetwork,
+			Message: fmt.Sprintf("failed to create request: %v", err),
+		}
+	}
+
+	g.setHeaders(req)
+
+	if err := g.rateLimiter.Wait(ctx, "api.github.com"); err != nil {
+		return err
+	}
+
+	resp, err := g.httpClient.Do(req)
+	if err != nil {
+		return &webscrape.ScrapeError{
+			Type:      webscrape.ErrNetwork,
+			Message:   fmt.Sprintf("request failed: %v", err),
+			Retryable: true,
+		}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return g.handleHTTPError(resp.StatusCode)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
+		return &webscrape.ScrapeError{
+			Type:    webscrape.ErrParseFailure,
+			Message: fmt.Sprintf("failed to parse response: %v", err),
+		}
+	}
+
+	return nil
+}
+
+// fetchRaw fetches raw content from a URL
+func (g *GitHubHandler) fetchRaw(ctx context.Context, rawURL string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	g.setHeaders(req)
+
+	domain := webscrape.ExtractDomain(rawURL)
+	if err := g.rateLimiter.Wait(ctx, domain); err != nil {
+		return nil, err
+	}
+
+	resp, err := g.httpClient.Do(req)
+	if err != nil {
+		return nil, &webscrape.ScrapeError{
+			Type:      webscrape.ErrNetwork,
+			Message:   fmt.Sprintf("failed to fetch raw content: %v", err),
+			Retryable: true,
+		}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, g.handleHTTPError(resp.StatusCode)
+	}
+
+	return io.ReadAll(resp.Body)
+}
+
+// setHeaders sets common headers for GitHub API requests
+func (g *GitHubHandler) setHeaders(req *http.Request) {
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "PedroCLI/1.0")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	if g.apiToken != "" {
+		req.Header.Set("Authorization", "Bearer "+g.apiToken)
+	}
+}
+
+// handleHTTPError converts HTTP status codes to ScrapeError
+func (g *GitHubHandler) handleHTTPError(statusCode int) *webscrape.ScrapeError {
+	switch statusCode {
+	case 401:
+		return &webscrape.ScrapeError{
+			Type:       webscrape.ErrAccessDenied,
+			Message:    "GitHub API authentication failed",
+			StatusCode: statusCode,
+			Suggestion: "Check your GitHub API token",
+		}
+	case 403:
+		return &webscrape.ScrapeError{
+			Type:       webscrape.ErrRateLimited,
+			Message:    "GitHub API rate limit exceeded",
+			StatusCode: statusCode,
+			Retryable:  true,
+			Suggestion: "Wait before making more requests or use an API token",
+		}
+	case 404:
+		return &webscrape.ScrapeError{
+			Type:       webscrape.ErrNotFound,
+			Message:    "resource not found on GitHub",
+			StatusCode: statusCode,
+			Suggestion: "Verify the repository, file path, or reference exists",
+		}
+	case 422:
+		return &webscrape.ScrapeError{
+			Type:       webscrape.ErrInvalidURL,
+			Message:    "GitHub API validation failed",
+			StatusCode: statusCode,
+			Suggestion: "Check your query parameters",
+		}
+	default:
+		return &webscrape.ScrapeError{
+			Type:       webscrape.ErrNetwork,
+			Message:    fmt.Sprintf("GitHub API error: %d", statusCode),
+			StatusCode: statusCode,
+			Retryable:  statusCode >= 500,
+		}
+	}
+}
+
+// detectLanguageFromPath determines language from file extension
+func detectLanguageFromPath(filePath string) string {
+	ext := strings.ToLower(path.Ext(filePath))
+
+	languages := map[string]string{
+		".go":     "go",
+		".py":     "python",
+		".js":     "javascript",
+		".ts":     "typescript",
+		".tsx":    "typescript",
+		".jsx":    "javascript",
+		".java":   "java",
+		".c":      "c",
+		".cpp":    "cpp",
+		".cc":     "cpp",
+		".h":      "c",
+		".hpp":    "cpp",
+		".rs":     "rust",
+		".rb":     "ruby",
+		".php":    "php",
+		".cs":     "csharp",
+		".swift":  "swift",
+		".kt":     "kotlin",
+		".scala":  "scala",
+		".sh":     "bash",
+		".bash":   "bash",
+		".zsh":    "zsh",
+		".md":     "markdown",
+		".json":   "json",
+		".yaml":   "yaml",
+		".yml":    "yaml",
+		".xml":    "xml",
+		".html":   "html",
+		".css":    "css",
+		".scss":   "scss",
+		".sql":    "sql",
+		".r":      "r",
+		".R":      "r",
+		".lua":    "lua",
+		".perl":   "perl",
+		".pl":     "perl",
+		".ex":     "elixir",
+		".exs":    "elixir",
+		".erl":    "erlang",
+		".clj":    "clojure",
+		".hs":     "haskell",
+		".ml":     "ocaml",
+		".fs":     "fsharp",
+		".dart":   "dart",
+		".vue":    "vue",
+		".svelte": "svelte",
+	}
+
+	if lang, ok := languages[ext]; ok {
+		return lang
+	}
+
+	return ""
+}
+
+// ParseGitHubURL parses a GitHub URL into owner, repo, path, and ref
+func ParseGitHubURL(rawURL string) (owner, repo, filePath, ref string, err error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", "", "", "", err
+	}
+
+	if !strings.Contains(parsed.Host, "github.com") {
+		return "", "", "", "", fmt.Errorf("not a GitHub URL")
+	}
+
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(parts) < 2 {
+		return "", "", "", "", fmt.Errorf("invalid GitHub URL format")
+	}
+
+	owner = parts[0]
+	repo = parts[1]
+
+	if len(parts) > 2 {
+		switch parts[2] {
+		case "blob", "tree":
+			if len(parts) > 3 {
+				ref = parts[3]
+				if len(parts) > 4 {
+					filePath = strings.Join(parts[4:], "/")
+				}
+			}
+		case "raw":
+			if len(parts) > 3 {
+				ref = parts[3]
+				if len(parts) > 4 {
+					filePath = strings.Join(parts[4:], "/")
+				}
+			}
+		}
+	}
+
+	return owner, repo, filePath, ref, nil
+}

--- a/pkg/webscrape/handlers/gitlab.go
+++ b/pkg/webscrape/handlers/gitlab.go
@@ -1,0 +1,456 @@
+package handlers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/soypete/pedrocli/pkg/webscrape"
+)
+
+// GitLabHandler handles GitLab-specific fetching operations
+type GitLabHandler struct {
+	baseURL     string // Support self-hosted GitLab instances
+	apiToken    string
+	httpClient  *http.Client
+	rateLimiter *webscrape.RateLimiter
+}
+
+// GitLabConfig configures the GitLab handler
+type GitLabConfig struct {
+	BaseURL  string // Default: "https://gitlab.com"
+	APIToken string // Optional, for private repos and higher rate limits
+	Timeout  time.Duration
+}
+
+// NewGitLabHandler creates a new GitLab handler
+func NewGitLabHandler(cfg *GitLabConfig) *GitLabHandler {
+	if cfg == nil {
+		cfg = &GitLabConfig{}
+	}
+
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = "https://gitlab.com"
+	}
+	baseURL = strings.TrimSuffix(baseURL, "/")
+
+	timeout := cfg.Timeout
+	if timeout == 0 {
+		timeout = 30 * time.Second
+	}
+
+	h := &GitLabHandler{
+		baseURL:  baseURL,
+		apiToken: cfg.APIToken,
+		httpClient: &http.Client{
+			Timeout: timeout,
+		},
+		rateLimiter: webscrape.NewRateLimiter(),
+	}
+
+	// Set rate limits for GitLab API
+	domain := webscrape.ExtractDomain(baseURL)
+	h.rateLimiter.SetLimit(domain, 10)
+
+	return h
+}
+
+// FetchFile fetches a file from a GitLab repository
+func (g *GitLabHandler) FetchFile(ctx context.Context, project, filePath, ref string) (*webscrape.GitLabFile, error) {
+	if ref == "" {
+		ref = "main"
+	}
+
+	// URL encode the project path and file path
+	encodedProject := url.PathEscape(project)
+	encodedPath := url.PathEscape(filePath)
+
+	apiURL := fmt.Sprintf("%s/api/v4/projects/%s/repository/files/%s?ref=%s",
+		g.baseURL,
+		encodedProject,
+		encodedPath,
+		url.QueryEscape(ref))
+
+	var content struct {
+		FileName      string `json:"file_name"`
+		FilePath      string `json:"file_path"`
+		Size          int    `json:"size"`
+		Encoding      string `json:"encoding"`
+		Content       string `json:"content"`
+		ContentSHA256 string `json:"content_sha256"`
+		Ref           string `json:"ref"`
+		BlobID        string `json:"blob_id"`
+		CommitID      string `json:"commit_id"`
+		LastCommitID  string `json:"last_commit_id"`
+	}
+
+	if err := g.doAPIRequest(ctx, apiURL, &content); err != nil {
+		return nil, err
+	}
+
+	// Decode content
+	var fileContent string
+	if content.Encoding == "base64" {
+		decoded, err := base64.StdEncoding.DecodeString(content.Content)
+		if err != nil {
+			return nil, &webscrape.ScrapeError{
+				Type:    webscrape.ErrParseFailure,
+				Message: fmt.Sprintf("failed to decode file content: %v", err),
+			}
+		}
+		fileContent = string(decoded)
+	} else {
+		fileContent = content.Content
+	}
+
+	// Detect language from extension
+	language := detectLanguageFromPath(content.FilePath)
+
+	// Build URL to the file in GitLab UI
+	fileURL := fmt.Sprintf("%s/%s/-/blob/%s/%s",
+		g.baseURL,
+		project,
+		ref,
+		filePath)
+
+	return &webscrape.GitLabFile{
+		Path:     content.FilePath,
+		Content:  fileContent,
+		Language: language,
+		Size:     content.Size,
+		BlobID:   content.BlobID,
+		URL:      fileURL,
+	}, nil
+}
+
+// FetchREADME fetches the README from a GitLab repository
+func (g *GitLabHandler) FetchREADME(ctx context.Context, project string) (*webscrape.GitLabFile, error) {
+	// Try common README filenames
+	readmeNames := []string{"README.md", "README.rst", "README.txt", "README", "readme.md"}
+
+	for _, name := range readmeNames {
+		file, err := g.FetchFile(ctx, project, name, "")
+		if err == nil {
+			return file, nil
+		}
+		// Continue to next filename if not found
+		if scrapeErr, ok := err.(*webscrape.ScrapeError); ok && scrapeErr.Type == webscrape.ErrNotFound {
+			continue
+		}
+		// Return other errors
+		return nil, err
+	}
+
+	return nil, &webscrape.ScrapeError{
+		Type:       webscrape.ErrNotFound,
+		Message:    "no README found in repository",
+		Suggestion: "The repository may not have a README file",
+	}
+}
+
+// FetchDirectory lists files in a GitLab repository directory
+func (g *GitLabHandler) FetchDirectory(ctx context.Context, project, dirPath, ref string) ([]webscrape.GitHubEntry, error) {
+	if ref == "" {
+		ref = "main"
+	}
+
+	encodedProject := url.PathEscape(project)
+
+	apiURL := fmt.Sprintf("%s/api/v4/projects/%s/repository/tree?path=%s&ref=%s",
+		g.baseURL,
+		encodedProject,
+		url.QueryEscape(dirPath),
+		url.QueryEscape(ref))
+
+	var items []struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+		Type string `json:"type"` // "blob" or "tree"
+		Path string `json:"path"`
+		Mode string `json:"mode"`
+	}
+
+	if err := g.doAPIRequest(ctx, apiURL, &items); err != nil {
+		return nil, err
+	}
+
+	var entries []webscrape.GitHubEntry
+	for _, item := range items {
+		entryType := "file"
+		if item.Type == "tree" {
+			entryType = "dir"
+		}
+
+		fileURL := fmt.Sprintf("%s/%s/-/blob/%s/%s",
+			g.baseURL,
+			project,
+			ref,
+			item.Path)
+
+		entries = append(entries, webscrape.GitHubEntry{
+			Name: item.Name,
+			Path: item.Path,
+			Type: entryType,
+			SHA:  item.ID,
+			URL:  fileURL,
+		})
+	}
+
+	return entries, nil
+}
+
+// SearchCode searches for code in a GitLab project or globally
+func (g *GitLabHandler) SearchCode(ctx context.Context, query string, opts *webscrape.GitLabSearchOpts) ([]webscrape.GitLabSearchResult, error) {
+	if opts == nil {
+		opts = &webscrape.GitLabSearchOpts{}
+	}
+
+	scope := opts.Scope
+	if scope == "" {
+		scope = "blobs"
+	}
+
+	perPage := opts.PerPage
+	if perPage == 0 {
+		perPage = 20
+	}
+
+	apiURL := fmt.Sprintf("%s/api/v4/search?scope=%s&search=%s&per_page=%d",
+		g.baseURL,
+		scope,
+		url.QueryEscape(query),
+		perPage)
+
+	var items []struct {
+		Basename  string `json:"basename"`
+		Data      string `json:"data"`
+		Path      string `json:"path"`
+		Filename  string `json:"filename"`
+		ID        string `json:"id"`
+		Ref       string `json:"ref"`
+		Startline int    `json:"startline"`
+		ProjectID int    `json:"project_id"`
+	}
+
+	if err := g.doAPIRequest(ctx, apiURL, &items); err != nil {
+		return nil, err
+	}
+
+	var results []webscrape.GitLabSearchResult
+	for _, item := range items {
+		results = append(results, webscrape.GitLabSearchResult{
+			Project:  fmt.Sprintf("%d", item.ProjectID), // Would need another API call to get project path
+			Path:     item.Path,
+			Ref:      item.Ref,
+			Fragment: item.Data,
+		})
+	}
+
+	return results, nil
+}
+
+// SearchInProject searches for code within a specific project
+func (g *GitLabHandler) SearchInProject(ctx context.Context, project, query string, opts *webscrape.GitLabSearchOpts) ([]webscrape.GitLabSearchResult, error) {
+	if opts == nil {
+		opts = &webscrape.GitLabSearchOpts{}
+	}
+
+	scope := opts.Scope
+	if scope == "" {
+		scope = "blobs"
+	}
+
+	perPage := opts.PerPage
+	if perPage == 0 {
+		perPage = 20
+	}
+
+	encodedProject := url.PathEscape(project)
+
+	apiURL := fmt.Sprintf("%s/api/v4/projects/%s/search?scope=%s&search=%s&per_page=%d",
+		g.baseURL,
+		encodedProject,
+		scope,
+		url.QueryEscape(query),
+		perPage)
+
+	var items []struct {
+		Basename  string `json:"basename"`
+		Data      string `json:"data"`
+		Path      string `json:"path"`
+		Filename  string `json:"filename"`
+		ID        string `json:"id"`
+		Ref       string `json:"ref"`
+		Startline int    `json:"startline"`
+	}
+
+	if err := g.doAPIRequest(ctx, apiURL, &items); err != nil {
+		return nil, err
+	}
+
+	var results []webscrape.GitLabSearchResult
+	for _, item := range items {
+		fileURL := fmt.Sprintf("%s/%s/-/blob/%s/%s",
+			g.baseURL,
+			project,
+			item.Ref,
+			item.Path)
+
+		results = append(results, webscrape.GitLabSearchResult{
+			Project:  project,
+			Path:     item.Path,
+			Ref:      item.Ref,
+			URL:      fileURL,
+			Fragment: item.Data,
+		})
+	}
+
+	return results, nil
+}
+
+// doAPIRequest performs an API request and decodes the JSON response
+func (g *GitLabHandler) doAPIRequest(ctx context.Context, apiURL string, result interface{}) error {
+	req, err := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
+	if err != nil {
+		return &webscrape.ScrapeError{
+			Type:    webscrape.ErrNetwork,
+			Message: fmt.Sprintf("failed to create request: %v", err),
+		}
+	}
+
+	g.setHeaders(req)
+
+	domain := webscrape.ExtractDomain(apiURL)
+	if err := g.rateLimiter.Wait(ctx, domain); err != nil {
+		return err
+	}
+
+	resp, err := g.httpClient.Do(req)
+	if err != nil {
+		return &webscrape.ScrapeError{
+			Type:      webscrape.ErrNetwork,
+			Message:   fmt.Sprintf("request failed: %v", err),
+			Retryable: true,
+		}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return g.handleHTTPError(resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return &webscrape.ScrapeError{
+			Type:    webscrape.ErrNetwork,
+			Message: fmt.Sprintf("failed to read response: %v", err),
+		}
+	}
+
+	if err := json.Unmarshal(body, result); err != nil {
+		return &webscrape.ScrapeError{
+			Type:    webscrape.ErrParseFailure,
+			Message: fmt.Sprintf("failed to parse response: %v", err),
+		}
+	}
+
+	return nil
+}
+
+// setHeaders sets common headers for GitLab API requests
+func (g *GitLabHandler) setHeaders(req *http.Request) {
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "PedroCLI/1.0")
+
+	if g.apiToken != "" {
+		req.Header.Set("PRIVATE-TOKEN", g.apiToken)
+	}
+}
+
+// handleHTTPError converts HTTP status codes to ScrapeError
+func (g *GitLabHandler) handleHTTPError(statusCode int) *webscrape.ScrapeError {
+	switch statusCode {
+	case 401:
+		return &webscrape.ScrapeError{
+			Type:       webscrape.ErrAccessDenied,
+			Message:    "GitLab API authentication failed",
+			StatusCode: statusCode,
+			Suggestion: "Check your GitLab API token",
+		}
+	case 403:
+		return &webscrape.ScrapeError{
+			Type:       webscrape.ErrAccessDenied,
+			Message:    "access denied to GitLab resource",
+			StatusCode: statusCode,
+			Suggestion: "You may not have permission to access this resource",
+		}
+	case 404:
+		return &webscrape.ScrapeError{
+			Type:       webscrape.ErrNotFound,
+			Message:    "resource not found on GitLab",
+			StatusCode: statusCode,
+			Suggestion: "Verify the project path, file path, or reference exists",
+		}
+	case 429:
+		return &webscrape.ScrapeError{
+			Type:       webscrape.ErrRateLimited,
+			Message:    "GitLab API rate limit exceeded",
+			StatusCode: statusCode,
+			Retryable:  true,
+			Suggestion: "Wait before making more requests",
+		}
+	default:
+		return &webscrape.ScrapeError{
+			Type:       webscrape.ErrNetwork,
+			Message:    fmt.Sprintf("GitLab API error: %d", statusCode),
+			StatusCode: statusCode,
+			Retryable:  statusCode >= 500,
+		}
+	}
+}
+
+// ParseGitLabURL parses a GitLab URL into project, path, and ref
+func ParseGitLabURL(rawURL string) (project, filePath, ref string, err error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	// Remove leading slash and split
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+
+	// Find the separator (-/blob, -/tree, -/raw)
+	separatorIdx := -1
+	for i, part := range parts {
+		if part == "-" && i+1 < len(parts) {
+			separatorIdx = i
+			break
+		}
+	}
+
+	if separatorIdx == -1 {
+		// No separator, just a project path
+		project = strings.Join(parts, "/")
+		return project, "", "", nil
+	}
+
+	project = strings.Join(parts[:separatorIdx], "/")
+
+	// After separator: ["-", "blob"|"tree"|"raw", ref, path...]
+	if separatorIdx+2 < len(parts) {
+		ref = parts[separatorIdx+2]
+	}
+
+	if separatorIdx+3 < len(parts) {
+		filePath = strings.Join(parts[separatorIdx+3:], "/")
+	}
+
+	return project, filePath, ref, nil
+}

--- a/pkg/webscrape/handlers/stackoverflow.go
+++ b/pkg/webscrape/handlers/stackoverflow.go
@@ -1,0 +1,505 @@
+package handlers
+
+import (
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/soypete/pedrocli/pkg/webscrape"
+)
+
+// StackOverflowHandler handles Stack Overflow-specific fetching operations
+type StackOverflowHandler struct {
+	apiKey      string
+	httpClient  *http.Client
+	rateLimiter *webscrape.RateLimiter
+	extractor   *webscrape.CodeExtractor
+}
+
+// StackOverflowConfig configures the Stack Overflow handler
+type StackOverflowConfig struct {
+	APIKey  string // Optional, for higher rate limits
+	Timeout time.Duration
+}
+
+// NewStackOverflowHandler creates a new Stack Overflow handler
+func NewStackOverflowHandler(cfg *StackOverflowConfig) *StackOverflowHandler {
+	if cfg == nil {
+		cfg = &StackOverflowConfig{}
+	}
+
+	timeout := cfg.Timeout
+	if timeout == 0 {
+		timeout = 30 * time.Second
+	}
+
+	h := &StackOverflowHandler{
+		apiKey: cfg.APIKey,
+		httpClient: &http.Client{
+			Timeout: timeout,
+		},
+		rateLimiter: webscrape.NewRateLimiter(),
+		extractor:   webscrape.NewCodeExtractor(),
+	}
+
+	// Stack Exchange API is generous with rate limits
+	h.rateLimiter.SetLimit("api.stackexchange.com", 30)
+
+	return h
+}
+
+// FetchQuestion fetches a Stack Overflow question by ID
+func (s *StackOverflowHandler) FetchQuestion(ctx context.Context, questionID int) (*webscrape.SOQuestion, error) {
+	apiURL := fmt.Sprintf("https://api.stackexchange.com/2.3/questions/%d?order=desc&sort=activity&site=stackoverflow&filter=withbody",
+		questionID)
+
+	if s.apiKey != "" {
+		apiURL += "&key=" + url.QueryEscape(s.apiKey)
+	}
+
+	var response struct {
+		Items []struct {
+			QuestionID       int      `json:"question_id"`
+			Title            string   `json:"title"`
+			Body             string   `json:"body"`
+			Tags             []string `json:"tags"`
+			Score            int      `json:"score"`
+			AcceptedAnswerID *int     `json:"accepted_answer_id"`
+			AnswerCount      int      `json:"answer_count"`
+			Link             string   `json:"link"`
+			CreationDate     int64    `json:"creation_date"`
+		} `json:"items"`
+		HasMore        bool `json:"has_more"`
+		QuotaMax       int  `json:"quota_max"`
+		QuotaRemaining int  `json:"quota_remaining"`
+	}
+
+	if err := s.doAPIRequest(ctx, apiURL, &response); err != nil {
+		return nil, err
+	}
+
+	if len(response.Items) == 0 {
+		return nil, &webscrape.ScrapeError{
+			Type:       webscrape.ErrNotFound,
+			Message:    fmt.Sprintf("question %d not found", questionID),
+			Suggestion: "Verify the question ID is correct",
+		}
+	}
+
+	item := response.Items[0]
+
+	// Extract code blocks from body
+	extracted, _ := s.extractor.Extract(item.Body, item.Link)
+	var codeBlocks []webscrape.CodeBlock
+	if extracted != nil {
+		codeBlocks = extracted.CodeBlocks
+	}
+
+	question := &webscrape.SOQuestion{
+		ID:           item.QuestionID,
+		Title:        item.Title,
+		Body:         item.Body,
+		BodyMarkdown: stripHTMLToMarkdown(item.Body),
+		Tags:         item.Tags,
+		Score:        item.Score,
+		AcceptedID:   item.AcceptedAnswerID,
+		URL:          item.Link,
+		CreatedAt:    time.Unix(item.CreationDate, 0),
+	}
+
+	// Set code blocks on first answer if any (will be replaced when fetching answers)
+	if len(codeBlocks) > 0 {
+		question.Answers = []webscrape.SOAnswer{{
+			CodeBlocks: codeBlocks,
+		}}
+	}
+
+	return question, nil
+}
+
+// FetchAnswers fetches answers for a Stack Overflow question
+func (s *StackOverflowHandler) FetchAnswers(ctx context.Context, questionID int, maxAnswers int) ([]webscrape.SOAnswer, error) {
+	if maxAnswers == 0 {
+		maxAnswers = 5
+	}
+
+	apiURL := fmt.Sprintf("https://api.stackexchange.com/2.3/questions/%d/answers?order=desc&sort=votes&site=stackoverflow&filter=withbody&pagesize=%d",
+		questionID, maxAnswers)
+
+	if s.apiKey != "" {
+		apiURL += "&key=" + url.QueryEscape(s.apiKey)
+	}
+
+	var response struct {
+		Items []struct {
+			AnswerID     int    `json:"answer_id"`
+			QuestionID   int    `json:"question_id"`
+			Body         string `json:"body"`
+			Score        int    `json:"score"`
+			IsAccepted   bool   `json:"is_accepted"`
+			Link         string `json:"link"`
+			CreationDate int64  `json:"creation_date"`
+		} `json:"items"`
+		HasMore        bool `json:"has_more"`
+		QuotaMax       int  `json:"quota_max"`
+		QuotaRemaining int  `json:"quota_remaining"`
+	}
+
+	if err := s.doAPIRequest(ctx, apiURL, &response); err != nil {
+		return nil, err
+	}
+
+	var answers []webscrape.SOAnswer
+	for _, item := range response.Items {
+		// Extract code blocks from answer body
+		extracted, _ := s.extractor.Extract(item.Body, "")
+		var codeBlocks []webscrape.CodeBlock
+		if extracted != nil {
+			codeBlocks = extracted.CodeBlocks
+		}
+
+		// Build answer URL
+		answerURL := fmt.Sprintf("https://stackoverflow.com/a/%d", item.AnswerID)
+
+		answers = append(answers, webscrape.SOAnswer{
+			ID:           item.AnswerID,
+			Body:         item.Body,
+			BodyMarkdown: stripHTMLToMarkdown(item.Body),
+			CodeBlocks:   codeBlocks,
+			Score:        item.Score,
+			IsAccepted:   item.IsAccepted,
+			URL:          answerURL,
+		})
+	}
+
+	return answers, nil
+}
+
+// FetchQuestionWithAnswers fetches a question with its answers
+func (s *StackOverflowHandler) FetchQuestionWithAnswers(ctx context.Context, questionID int, maxAnswers int) (*webscrape.SOQuestion, error) {
+	question, err := s.FetchQuestion(ctx, questionID)
+	if err != nil {
+		return nil, err
+	}
+
+	answers, err := s.FetchAnswers(ctx, questionID, maxAnswers)
+	if err != nil {
+		// Return question without answers if fetch fails
+		return question, nil
+	}
+
+	question.Answers = answers
+	return question, nil
+}
+
+// SearchQuestions searches Stack Overflow for questions
+func (s *StackOverflowHandler) SearchQuestions(ctx context.Context, query string, tags []string, sort string, maxResults int) ([]webscrape.SOSearchResult, error) {
+	if sort == "" {
+		sort = "relevance"
+	}
+	if maxResults == 0 {
+		maxResults = 10
+	}
+
+	// Build search URL
+	params := url.Values{}
+	params.Set("order", "desc")
+	params.Set("sort", sort)
+	params.Set("site", "stackoverflow")
+	params.Set("pagesize", strconv.Itoa(maxResults))
+	params.Set("intitle", query)
+
+	if len(tags) > 0 {
+		params.Set("tagged", strings.Join(tags, ";"))
+	}
+
+	if s.apiKey != "" {
+		params.Set("key", s.apiKey)
+	}
+
+	apiURL := "https://api.stackexchange.com/2.3/search/advanced?" + params.Encode()
+
+	var response struct {
+		Items []struct {
+			QuestionID  int      `json:"question_id"`
+			Title       string   `json:"title"`
+			Tags        []string `json:"tags"`
+			Score       int      `json:"score"`
+			AnswerCount int      `json:"answer_count"`
+			IsAnswered  bool     `json:"is_answered"`
+			Link        string   `json:"link"`
+		} `json:"items"`
+		HasMore        bool `json:"has_more"`
+		QuotaMax       int  `json:"quota_max"`
+		QuotaRemaining int  `json:"quota_remaining"`
+	}
+
+	if err := s.doAPIRequest(ctx, apiURL, &response); err != nil {
+		return nil, err
+	}
+
+	var results []webscrape.SOSearchResult
+	for _, item := range response.Items {
+		results = append(results, webscrape.SOSearchResult{
+			ID:        item.QuestionID,
+			Title:     item.Title,
+			Tags:      item.Tags,
+			Score:     item.Score,
+			Answers:   item.AnswerCount,
+			URL:       item.Link,
+			IsAnswerd: item.IsAnswered,
+		})
+	}
+
+	return results, nil
+}
+
+// doAPIRequest performs an API request and decodes the JSON response
+func (s *StackOverflowHandler) doAPIRequest(ctx context.Context, apiURL string, result interface{}) error {
+	req, err := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
+	if err != nil {
+		return &webscrape.ScrapeError{
+			Type:    webscrape.ErrNetwork,
+			Message: fmt.Sprintf("failed to create request: %v", err),
+		}
+	}
+
+	// Stack Exchange API returns gzip-compressed responses
+	req.Header.Set("Accept-Encoding", "gzip")
+	req.Header.Set("User-Agent", "PedroCLI/1.0")
+
+	if err := s.rateLimiter.Wait(ctx, "api.stackexchange.com"); err != nil {
+		return err
+	}
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return &webscrape.ScrapeError{
+			Type:      webscrape.ErrNetwork,
+			Message:   fmt.Sprintf("request failed: %v", err),
+			Retryable: true,
+		}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return s.handleHTTPError(resp.StatusCode)
+	}
+
+	// Handle gzip compression
+	var reader io.Reader = resp.Body
+	if resp.Header.Get("Content-Encoding") == "gzip" {
+		gzReader, err := gzip.NewReader(resp.Body)
+		if err != nil {
+			return &webscrape.ScrapeError{
+				Type:    webscrape.ErrParseFailure,
+				Message: fmt.Sprintf("failed to decompress response: %v", err),
+			}
+		}
+		defer gzReader.Close()
+		reader = gzReader
+	}
+
+	body, err := io.ReadAll(reader)
+	if err != nil {
+		return &webscrape.ScrapeError{
+			Type:    webscrape.ErrNetwork,
+			Message: fmt.Sprintf("failed to read response: %v", err),
+		}
+	}
+
+	if err := json.Unmarshal(body, result); err != nil {
+		return &webscrape.ScrapeError{
+			Type:    webscrape.ErrParseFailure,
+			Message: fmt.Sprintf("failed to parse response: %v", err),
+		}
+	}
+
+	return nil
+}
+
+// handleHTTPError converts HTTP status codes to ScrapeError
+func (s *StackOverflowHandler) handleHTTPError(statusCode int) *webscrape.ScrapeError {
+	switch statusCode {
+	case 400:
+		return &webscrape.ScrapeError{
+			Type:       webscrape.ErrInvalidURL,
+			Message:    "bad request to Stack Exchange API",
+			StatusCode: statusCode,
+			Suggestion: "Check your query parameters",
+		}
+	case 401, 403:
+		return &webscrape.ScrapeError{
+			Type:       webscrape.ErrAccessDenied,
+			Message:    "access denied to Stack Exchange API",
+			StatusCode: statusCode,
+			Suggestion: "Check your API key",
+		}
+	case 404:
+		return &webscrape.ScrapeError{
+			Type:       webscrape.ErrNotFound,
+			Message:    "resource not found on Stack Overflow",
+			StatusCode: statusCode,
+			Suggestion: "Verify the question ID is correct",
+		}
+	case 429:
+		return &webscrape.ScrapeError{
+			Type:       webscrape.ErrRateLimited,
+			Message:    "Stack Exchange API rate limit exceeded",
+			StatusCode: statusCode,
+			Retryable:  true,
+			Suggestion: "Wait before making more requests or use an API key",
+		}
+	case 502, 503:
+		return &webscrape.ScrapeError{
+			Type:       webscrape.ErrNetwork,
+			Message:    "Stack Exchange API temporarily unavailable",
+			StatusCode: statusCode,
+			Retryable:  true,
+			Suggestion: "Try again in a few seconds",
+		}
+	default:
+		return &webscrape.ScrapeError{
+			Type:       webscrape.ErrNetwork,
+			Message:    fmt.Sprintf("Stack Exchange API error: %d", statusCode),
+			StatusCode: statusCode,
+			Retryable:  statusCode >= 500,
+		}
+	}
+}
+
+// stripHTMLToMarkdown converts HTML to a simple markdown-like format
+func stripHTMLToMarkdown(html string) string {
+	// This is a simple conversion - for production, consider a proper HTML to markdown library
+	result := html
+
+	// Convert code blocks
+	result = strings.ReplaceAll(result, "<pre><code>", "\n```\n")
+	result = strings.ReplaceAll(result, "</code></pre>", "\n```\n")
+	result = strings.ReplaceAll(result, "<pre>", "\n```\n")
+	result = strings.ReplaceAll(result, "</pre>", "\n```\n")
+	result = strings.ReplaceAll(result, "<code>", "`")
+	result = strings.ReplaceAll(result, "</code>", "`")
+
+	// Convert lists
+	result = strings.ReplaceAll(result, "<li>", "- ")
+	result = strings.ReplaceAll(result, "</li>", "\n")
+	result = strings.ReplaceAll(result, "<ul>", "\n")
+	result = strings.ReplaceAll(result, "</ul>", "\n")
+	result = strings.ReplaceAll(result, "<ol>", "\n")
+	result = strings.ReplaceAll(result, "</ol>", "\n")
+
+	// Convert paragraphs and line breaks
+	result = strings.ReplaceAll(result, "<p>", "\n\n")
+	result = strings.ReplaceAll(result, "</p>", "")
+	result = strings.ReplaceAll(result, "<br>", "\n")
+	result = strings.ReplaceAll(result, "<br/>", "\n")
+	result = strings.ReplaceAll(result, "<br />", "\n")
+
+	// Convert headers
+	result = strings.ReplaceAll(result, "<h1>", "\n# ")
+	result = strings.ReplaceAll(result, "</h1>", "\n")
+	result = strings.ReplaceAll(result, "<h2>", "\n## ")
+	result = strings.ReplaceAll(result, "</h2>", "\n")
+	result = strings.ReplaceAll(result, "<h3>", "\n### ")
+	result = strings.ReplaceAll(result, "</h3>", "\n")
+
+	// Convert bold and italic
+	result = strings.ReplaceAll(result, "<strong>", "**")
+	result = strings.ReplaceAll(result, "</strong>", "**")
+	result = strings.ReplaceAll(result, "<b>", "**")
+	result = strings.ReplaceAll(result, "</b>", "**")
+	result = strings.ReplaceAll(result, "<em>", "*")
+	result = strings.ReplaceAll(result, "</em>", "*")
+	result = strings.ReplaceAll(result, "<i>", "*")
+	result = strings.ReplaceAll(result, "</i>", "*")
+
+	// Strip remaining HTML tags
+	inTag := false
+	var cleaned strings.Builder
+	for _, r := range result {
+		if r == '<' {
+			inTag = true
+			continue
+		}
+		if r == '>' {
+			inTag = false
+			continue
+		}
+		if !inTag {
+			cleaned.WriteRune(r)
+		}
+	}
+
+	// Decode HTML entities
+	text := cleaned.String()
+	text = strings.ReplaceAll(text, "&amp;", "&")
+	text = strings.ReplaceAll(text, "&lt;", "<")
+	text = strings.ReplaceAll(text, "&gt;", ">")
+	text = strings.ReplaceAll(text, "&quot;", `"`)
+	text = strings.ReplaceAll(text, "&#39;", "'")
+	text = strings.ReplaceAll(text, "&nbsp;", " ")
+
+	return strings.TrimSpace(text)
+}
+
+// ParseStackOverflowURL parses a Stack Overflow URL to extract question/answer ID
+func ParseStackOverflowURL(rawURL string) (questionID int, answerID int, err error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	if !strings.Contains(parsed.Host, "stackoverflow.com") {
+		return 0, 0, fmt.Errorf("not a Stack Overflow URL")
+	}
+
+	path := strings.Trim(parsed.Path, "/")
+	parts := strings.Split(path, "/")
+
+	// Handle different URL formats:
+	// /questions/123456/title
+	// /questions/123456
+	// /a/123456
+	// /q/123456
+
+	for i, part := range parts {
+		switch part {
+		case "questions", "q":
+			if i+1 < len(parts) {
+				id, err := strconv.Atoi(parts[i+1])
+				if err == nil {
+					questionID = id
+				}
+			}
+		case "a":
+			if i+1 < len(parts) {
+				id, err := strconv.Atoi(parts[i+1])
+				if err == nil {
+					answerID = id
+				}
+			}
+		}
+	}
+
+	// Check for answer hash in URL (e.g., #123456)
+	if parsed.Fragment != "" {
+		id, err := strconv.Atoi(parsed.Fragment)
+		if err == nil {
+			answerID = id
+		}
+	}
+
+	if questionID == 0 && answerID == 0 {
+		return 0, 0, fmt.Errorf("could not parse question or answer ID from URL")
+	}
+
+	return questionID, answerID, nil
+}

--- a/pkg/webscrape/ratelimit.go
+++ b/pkg/webscrape/ratelimit.go
@@ -1,0 +1,172 @@
+package webscrape
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// RateLimiter manages rate limiting per domain
+type RateLimiter struct {
+	limiters map[string]*tokenBucket
+	defaults float64
+	mu       sync.RWMutex
+}
+
+// tokenBucket implements a simple token bucket rate limiter
+type tokenBucket struct {
+	tokens     float64
+	maxTokens  float64
+	refillRate float64 // tokens per second
+	lastRefill time.Time
+	mu         sync.Mutex
+}
+
+// NewRateLimiter creates a new rate limiter with default limits
+func NewRateLimiter() *RateLimiter {
+	rl := &RateLimiter{
+		limiters: make(map[string]*tokenBucket),
+		defaults: DefaultRateLimits["default"],
+	}
+
+	// Initialize with default limits for known domains
+	for domain, rate := range DefaultRateLimits {
+		if domain != "default" {
+			rl.SetLimit(domain, rate)
+		}
+	}
+
+	return rl
+}
+
+// SetLimit sets the rate limit for a specific domain
+func (r *RateLimiter) SetLimit(domain string, reqPerSecond float64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.limiters[domain] = &tokenBucket{
+		tokens:     reqPerSecond, // Start with full bucket
+		maxTokens:  reqPerSecond,
+		refillRate: reqPerSecond,
+		lastRefill: time.Now(),
+	}
+}
+
+// Wait blocks until a request can be made to the given domain
+func (r *RateLimiter) Wait(ctx context.Context, domain string) error {
+	bucket := r.getBucket(domain)
+
+	for {
+		bucket.mu.Lock()
+
+		// Refill tokens based on elapsed time
+		now := time.Now()
+		elapsed := now.Sub(bucket.lastRefill).Seconds()
+		bucket.tokens += elapsed * bucket.refillRate
+		if bucket.tokens > bucket.maxTokens {
+			bucket.tokens = bucket.maxTokens
+		}
+		bucket.lastRefill = now
+
+		// Check if we can proceed
+		if bucket.tokens >= 1 {
+			bucket.tokens--
+			bucket.mu.Unlock()
+			return nil
+		}
+
+		// Calculate wait time
+		waitTime := time.Duration((1 - bucket.tokens) / bucket.refillRate * float64(time.Second))
+		bucket.mu.Unlock()
+
+		// Wait for either context cancellation or wait time
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(waitTime):
+			// Continue to try again
+		}
+	}
+}
+
+// TryAcquire attempts to acquire a request slot without blocking
+func (r *RateLimiter) TryAcquire(domain string) bool {
+	bucket := r.getBucket(domain)
+
+	bucket.mu.Lock()
+	defer bucket.mu.Unlock()
+
+	// Refill tokens based on elapsed time
+	now := time.Now()
+	elapsed := now.Sub(bucket.lastRefill).Seconds()
+	bucket.tokens += elapsed * bucket.refillRate
+	if bucket.tokens > bucket.maxTokens {
+		bucket.tokens = bucket.maxTokens
+	}
+	bucket.lastRefill = now
+
+	// Check if we can proceed
+	if bucket.tokens >= 1 {
+		bucket.tokens--
+		return true
+	}
+
+	return false
+}
+
+// getBucket returns the rate limiter bucket for a domain
+func (r *RateLimiter) getBucket(domain string) *tokenBucket {
+	r.mu.RLock()
+	bucket, exists := r.limiters[domain]
+	r.mu.RUnlock()
+
+	if exists {
+		return bucket
+	}
+
+	// Create a new bucket with default rate
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Double-check after acquiring write lock
+	if bucket, exists = r.limiters[domain]; exists {
+		return bucket
+	}
+
+	bucket = &tokenBucket{
+		tokens:     r.defaults,
+		maxTokens:  r.defaults,
+		refillRate: r.defaults,
+		lastRefill: time.Now(),
+	}
+	r.limiters[domain] = bucket
+
+	return bucket
+}
+
+// ExtractDomain extracts the domain from a URL string
+func ExtractDomain(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+
+	host := parsed.Host
+	// Remove port if present
+	if idx := strings.LastIndex(host, ":"); idx != -1 {
+		host = host[:idx]
+	}
+
+	return strings.ToLower(host)
+}
+
+// WaitForURL is a convenience method that extracts the domain and waits
+func (r *RateLimiter) WaitForURL(ctx context.Context, rawURL string) error {
+	domain := ExtractDomain(rawURL)
+	if domain == "" {
+		return nil // Don't rate limit if we can't parse the URL
+	}
+	return r.Wait(ctx, domain)
+}

--- a/pkg/webscrape/ratelimit_test.go
+++ b/pkg/webscrape/ratelimit_test.go
@@ -1,0 +1,135 @@
+package webscrape
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestNewRateLimiter(t *testing.T) {
+	rl := NewRateLimiter()
+	if rl == nil {
+		t.Fatal("NewRateLimiter() returned nil")
+	}
+	if rl.limiters == nil {
+		t.Error("limiters map is nil")
+	}
+}
+
+func TestRateLimiterSetLimit(t *testing.T) {
+	rl := NewRateLimiter()
+	rl.SetLimit("example.com", 5.0)
+
+	// Check that we can get the bucket
+	bucket := rl.getBucket("example.com")
+	if bucket == nil {
+		t.Fatal("getBucket returned nil")
+	}
+	if bucket.refillRate != 5.0 {
+		t.Errorf("refillRate = %v, want 5.0", bucket.refillRate)
+	}
+}
+
+func TestRateLimiterTryAcquire(t *testing.T) {
+	rl := NewRateLimiter()
+	rl.SetLimit("test.com", 2.0) // 2 requests per second
+
+	// First request should succeed
+	if !rl.TryAcquire("test.com") {
+		t.Error("First TryAcquire should succeed")
+	}
+
+	// Second request should succeed
+	if !rl.TryAcquire("test.com") {
+		t.Error("Second TryAcquire should succeed")
+	}
+
+	// Third request may fail (depends on timing)
+	// Just check that it doesn't panic
+	_ = rl.TryAcquire("test.com")
+}
+
+func TestRateLimiterWait(t *testing.T) {
+	rl := NewRateLimiter()
+	rl.SetLimit("wait-test.com", 10.0) // High rate to avoid waiting
+
+	ctx := context.Background()
+
+	// Should not block with high rate
+	start := time.Now()
+	err := rl.Wait(ctx, "wait-test.com")
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Errorf("Wait() error = %v", err)
+	}
+	if elapsed > 100*time.Millisecond {
+		t.Errorf("Wait took too long: %v", elapsed)
+	}
+}
+
+func TestRateLimiterWaitCancellation(t *testing.T) {
+	rl := NewRateLimiter()
+	rl.SetLimit("cancel-test.com", 0.1) // Very low rate
+
+	// Exhaust the bucket
+	_ = rl.TryAcquire("cancel-test.com")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := rl.Wait(ctx, "cancel-test.com")
+	if err == nil {
+		t.Error("Wait() should return error on cancellation")
+	}
+}
+
+func TestExtractDomain(t *testing.T) {
+	tests := []struct {
+		url      string
+		expected string
+	}{
+		{"https://example.com/path", "example.com"},
+		{"http://api.example.com:8080/api", "api.example.com"},
+		{"https://GITHUB.COM/user/repo", "github.com"},
+		{"invalid-url", ""},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			result := ExtractDomain(tt.url)
+			if result != tt.expected {
+				t.Errorf("ExtractDomain(%q) = %q, want %q", tt.url, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRateLimiterWaitForURL(t *testing.T) {
+	rl := NewRateLimiter()
+
+	ctx := context.Background()
+
+	// Test with valid URL
+	err := rl.WaitForURL(ctx, "https://example.com/test")
+	if err != nil {
+		t.Errorf("WaitForURL() error = %v", err)
+	}
+
+	// Test with invalid URL (should not error)
+	err = rl.WaitForURL(ctx, "not-a-url")
+	if err != nil {
+		t.Errorf("WaitForURL() with invalid URL should not error, got %v", err)
+	}
+}
+
+func TestDefaultRateLimits(t *testing.T) {
+	// Ensure default limits are set
+	if DefaultRateLimits["github.com"] == 0 {
+		t.Error("github.com should have a default rate limit")
+	}
+	if DefaultRateLimits["default"] == 0 {
+		t.Error("default rate limit should be set")
+	}
+}

--- a/pkg/webscrape/search.go
+++ b/pkg/webscrape/search.go
@@ -1,0 +1,388 @@
+package webscrape
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// SearchEngine defines the interface for web search engines
+type SearchEngine interface {
+	Search(ctx context.Context, query string, opts *SearchOptions) ([]SearchResult, error)
+}
+
+// DuckDuckGoSearch implements search using DuckDuckGo
+type DuckDuckGoSearch struct {
+	httpClient  *http.Client
+	rateLimiter *RateLimiter
+}
+
+// NewDuckDuckGoSearch creates a new DuckDuckGo search engine
+func NewDuckDuckGoSearch() *DuckDuckGoSearch {
+	return &DuckDuckGoSearch{
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		rateLimiter: NewRateLimiter(),
+	}
+}
+
+// Search performs a search using DuckDuckGo's HTML interface
+// Note: DuckDuckGo doesn't have a free public API, so we use their HTML interface
+func (d *DuckDuckGoSearch) Search(ctx context.Context, query string, opts *SearchOptions) ([]SearchResult, error) {
+	if opts == nil {
+		opts = DefaultSearchOptions()
+	}
+
+	// Build search query
+	q := query
+	if opts.Site != "" {
+		q = fmt.Sprintf("site:%s %s", opts.Site, query)
+	}
+	if opts.FileType != "" {
+		q = fmt.Sprintf("filetype:%s %s", opts.FileType, q)
+	}
+
+	// Use DuckDuckGo HTML version (no API key needed)
+	// We'll use the lite version for easier parsing
+	searchURL := fmt.Sprintf("https://html.duckduckgo.com/html/?q=%s", url.QueryEscape(q))
+
+	if err := d.rateLimiter.Wait(ctx, "duckduckgo.com"); err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", searchURL, nil)
+	if err != nil {
+		return nil, &ScrapeError{
+			Type:    ErrNetwork,
+			Message: fmt.Sprintf("failed to create request: %v", err),
+		}
+	}
+
+	req.Header.Set("User-Agent", "PedroCLI/1.0 (Web Scraping Tool)")
+
+	resp, err := d.httpClient.Do(req)
+	if err != nil {
+		return nil, &ScrapeError{
+			Type:      ErrNetwork,
+			Message:   fmt.Sprintf("search request failed: %v", err),
+			Retryable: true,
+		}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &ScrapeError{
+			Type:       ErrNetwork,
+			Message:    fmt.Sprintf("search returned status %d", resp.StatusCode),
+			StatusCode: resp.StatusCode,
+			Retryable:  resp.StatusCode >= 500,
+		}
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, &ScrapeError{
+			Type:    ErrNetwork,
+			Message: fmt.Sprintf("failed to read response: %v", err),
+		}
+	}
+
+	return d.parseResults(string(body), opts.MaxResults)
+}
+
+// parseResults parses search results from DuckDuckGo HTML
+func (d *DuckDuckGoSearch) parseResults(html string, maxResults int) ([]SearchResult, error) {
+	var results []SearchResult
+
+	// Simple parsing of DuckDuckGo HTML results
+	// Look for result links with class "result__a"
+	// Format: <a rel="nofollow" class="result__a" href="...">Title</a>
+
+	// Split by result divs
+	parts := strings.Split(html, `class="result__body"`)
+
+	for _, part := range parts[1:] { // Skip first part (before results)
+		if len(results) >= maxResults {
+			break
+		}
+
+		// Find title and URL
+		titleStart := strings.Index(part, `class="result__a"`)
+		if titleStart == -1 {
+			continue
+		}
+
+		// Find href
+		hrefStart := strings.Index(part[titleStart:], `href="`)
+		if hrefStart == -1 {
+			continue
+		}
+		hrefStart += titleStart + 6 // Move past 'href="'
+
+		hrefEnd := strings.Index(part[hrefStart:], `"`)
+		if hrefEnd == -1 {
+			continue
+		}
+
+		rawURL := part[hrefStart : hrefStart+hrefEnd]
+
+		// DuckDuckGo uses redirect URLs, extract the actual URL
+		actualURL := extractDDGURL(rawURL)
+		if actualURL == "" {
+			actualURL = rawURL
+		}
+
+		// Find title text
+		titleTextStart := strings.Index(part[hrefStart:], ">")
+		if titleTextStart == -1 {
+			continue
+		}
+		titleTextStart += hrefStart + 1
+
+		titleTextEnd := strings.Index(part[titleTextStart:], "</a>")
+		if titleTextEnd == -1 {
+			continue
+		}
+
+		title := stripTags(part[titleTextStart : titleTextStart+titleTextEnd])
+
+		// Find snippet
+		snippetStart := strings.Index(part, `class="result__snippet"`)
+		snippet := ""
+		if snippetStart != -1 {
+			snippetTextStart := strings.Index(part[snippetStart:], ">")
+			if snippetTextStart != -1 {
+				snippetTextStart += snippetStart + 1
+				snippetTextEnd := strings.Index(part[snippetTextStart:], "</a>")
+				if snippetTextEnd == -1 {
+					snippetTextEnd = strings.Index(part[snippetTextStart:], "</span>")
+				}
+				if snippetTextEnd != -1 {
+					snippet = stripTags(part[snippetTextStart : snippetTextStart+snippetTextEnd])
+				}
+			}
+		}
+
+		if title != "" && actualURL != "" {
+			results = append(results, SearchResult{
+				Title:   strings.TrimSpace(title),
+				URL:     actualURL,
+				Snippet: strings.TrimSpace(snippet),
+				Source:  "duckduckgo",
+			})
+		}
+	}
+
+	return results, nil
+}
+
+// extractDDGURL extracts the actual URL from DuckDuckGo redirect URL
+func extractDDGURL(ddgURL string) string {
+	// DuckDuckGo uses URLs like:
+	// //duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2F&rut=...
+	if strings.Contains(ddgURL, "uddg=") {
+		parsed, err := url.Parse(ddgURL)
+		if err != nil {
+			return ""
+		}
+		uddg := parsed.Query().Get("uddg")
+		if uddg != "" {
+			decoded, err := url.QueryUnescape(uddg)
+			if err == nil {
+				return decoded
+			}
+		}
+	}
+	return ddgURL
+}
+
+// stripTags removes HTML tags from a string
+func stripTags(s string) string {
+	inTag := false
+	var result strings.Builder
+	for _, r := range s {
+		if r == '<' {
+			inTag = true
+			continue
+		}
+		if r == '>' {
+			inTag = false
+			continue
+		}
+		if !inTag {
+			result.WriteRune(r)
+		}
+	}
+	text := result.String()
+	text = strings.ReplaceAll(text, "&amp;", "&")
+	text = strings.ReplaceAll(text, "&lt;", "<")
+	text = strings.ReplaceAll(text, "&gt;", ">")
+	text = strings.ReplaceAll(text, "&quot;", `"`)
+	text = strings.ReplaceAll(text, "&#39;", "'")
+	text = strings.ReplaceAll(text, "&nbsp;", " ")
+	return text
+}
+
+// SearXNGSearch implements search using a SearXNG instance
+type SearXNGSearch struct {
+	baseURL     string
+	httpClient  *http.Client
+	rateLimiter *RateLimiter
+}
+
+// NewSearXNGSearch creates a new SearXNG search engine
+func NewSearXNGSearch(baseURL string) *SearXNGSearch {
+	return &SearXNGSearch{
+		baseURL: strings.TrimSuffix(baseURL, "/"),
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		rateLimiter: NewRateLimiter(),
+	}
+}
+
+// Search performs a search using a SearXNG instance
+func (s *SearXNGSearch) Search(ctx context.Context, query string, opts *SearchOptions) ([]SearchResult, error) {
+	if opts == nil {
+		opts = DefaultSearchOptions()
+	}
+
+	// Build search query
+	q := query
+	if opts.Site != "" {
+		q = fmt.Sprintf("site:%s %s", opts.Site, query)
+	}
+
+	// SearXNG JSON API
+	params := url.Values{}
+	params.Set("q", q)
+	params.Set("format", "json")
+	params.Set("categories", "general")
+
+	if opts.SafeSearch {
+		params.Set("safesearch", "1")
+	}
+
+	searchURL := fmt.Sprintf("%s/search?%s", s.baseURL, params.Encode())
+
+	domain := ExtractDomain(s.baseURL)
+	if err := s.rateLimiter.Wait(ctx, domain); err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", searchURL, nil)
+	if err != nil {
+		return nil, &ScrapeError{
+			Type:    ErrNetwork,
+			Message: fmt.Sprintf("failed to create request: %v", err),
+		}
+	}
+
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "PedroCLI/1.0")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, &ScrapeError{
+			Type:      ErrNetwork,
+			Message:   fmt.Sprintf("search request failed: %v", err),
+			Retryable: true,
+		}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &ScrapeError{
+			Type:       ErrNetwork,
+			Message:    fmt.Sprintf("search returned status %d", resp.StatusCode),
+			StatusCode: resp.StatusCode,
+		}
+	}
+
+	var response struct {
+		Results []struct {
+			Title   string `json:"title"`
+			URL     string `json:"url"`
+			Content string `json:"content"`
+			Engine  string `json:"engine"`
+		} `json:"results"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, &ScrapeError{
+			Type:    ErrParseFailure,
+			Message: fmt.Sprintf("failed to parse response: %v", err),
+		}
+	}
+
+	var results []SearchResult
+	for i, r := range response.Results {
+		if i >= opts.MaxResults {
+			break
+		}
+		results = append(results, SearchResult{
+			Title:   r.Title,
+			URL:     r.URL,
+			Snippet: r.Content,
+			Source:  "searxng",
+		})
+	}
+
+	return results, nil
+}
+
+// MetaSearch aggregates results from multiple search engines
+type MetaSearch struct {
+	engines []SearchEngine
+}
+
+// NewMetaSearch creates a new meta search engine
+func NewMetaSearch(engines ...SearchEngine) *MetaSearch {
+	return &MetaSearch{
+		engines: engines,
+	}
+}
+
+// Search performs a search across all configured engines
+func (m *MetaSearch) Search(ctx context.Context, query string, opts *SearchOptions) ([]SearchResult, error) {
+	if opts == nil {
+		opts = DefaultSearchOptions()
+	}
+
+	var allResults []SearchResult
+	seen := make(map[string]bool)
+
+	for _, engine := range m.engines {
+		results, err := engine.Search(ctx, query, opts)
+		if err != nil {
+			// Continue with other engines
+			continue
+		}
+
+		for _, r := range results {
+			// Deduplicate by URL
+			if !seen[r.URL] {
+				seen[r.URL] = true
+				allResults = append(allResults, r)
+			}
+		}
+
+		// Stop if we have enough results
+		if len(allResults) >= opts.MaxResults {
+			break
+		}
+	}
+
+	// Limit to requested number
+	if len(allResults) > opts.MaxResults {
+		allResults = allResults[:opts.MaxResults]
+	}
+
+	return allResults, nil
+}

--- a/pkg/webscrape/types.go
+++ b/pkg/webscrape/types.go
@@ -1,0 +1,320 @@
+// Package webscrape provides web scraping capabilities for fetching code and documentation
+// from external sources like GitHub, GitLab, Stack Overflow, and general web pages.
+package webscrape
+
+import (
+	"time"
+)
+
+// FetchOptions configures how a URL should be fetched
+type FetchOptions struct {
+	UserAgent       string            // HTTP User-Agent header
+	Timeout         time.Duration     // Request timeout
+	FollowRedirects bool              // Whether to follow HTTP redirects
+	MaxSize         int64             // Maximum response size in bytes
+	Headers         map[string]string // Additional HTTP headers
+	ExtractContent  bool              // Strip HTML, return clean text
+	ExtractCode     bool              // Extract code blocks specifically
+}
+
+// DefaultFetchOptions returns sensible default fetch options
+func DefaultFetchOptions() *FetchOptions {
+	return &FetchOptions{
+		UserAgent:       "PedroCLI/1.0 (Web Scraping Tool)",
+		Timeout:         30 * time.Second,
+		FollowRedirects: true,
+		MaxSize:         10 * 1024 * 1024, // 10MB
+		ExtractContent:  true,
+		ExtractCode:     true,
+	}
+}
+
+// FetchResult contains the result of fetching a URL
+type FetchResult struct {
+	URL         string      `json:"url"`
+	StatusCode  int         `json:"status_code"`
+	ContentType string      `json:"content_type"`
+	RawHTML     string      `json:"raw_html,omitempty"`
+	CleanText   string      `json:"clean_text,omitempty"`
+	CodeBlocks  []CodeBlock `json:"code_blocks,omitempty"`
+	Links       []Link      `json:"links,omitempty"`
+	Title       string      `json:"title,omitempty"`
+	Description string      `json:"description,omitempty"`
+	FetchedAt   time.Time   `json:"fetched_at"`
+}
+
+// CodeBlock represents an extracted code block from a page
+type CodeBlock struct {
+	Language string `json:"language,omitempty"`
+	Code     string `json:"code"`
+	Context  string `json:"context,omitempty"` // Surrounding text/description
+	LineNum  int    `json:"line_num,omitempty"`
+}
+
+// Link represents an extracted hyperlink
+type Link struct {
+	Text string `json:"text"`
+	URL  string `json:"url"`
+	Type string `json:"type,omitempty"` // documentation, source, reference
+}
+
+// SearchOptions configures web search behavior
+type SearchOptions struct {
+	MaxResults int    // Maximum number of results to return
+	SafeSearch bool   // Enable safe search filtering
+	TimeRange  string // day, week, month, year
+	Site       string // Limit to specific site (e.g., "github.com")
+	FileType   string // Limit to file type
+}
+
+// DefaultSearchOptions returns sensible default search options
+func DefaultSearchOptions() *SearchOptions {
+	return &SearchOptions{
+		MaxResults: 10,
+		SafeSearch: true,
+	}
+}
+
+// SearchResult represents a single search result
+type SearchResult struct {
+	Title   string `json:"title"`
+	URL     string `json:"url"`
+	Snippet string `json:"snippet"`
+	Source  string `json:"source"` // google, duckduckgo, etc.
+}
+
+// ExtractedContent represents content extracted from an HTML page
+type ExtractedContent struct {
+	Title      string            `json:"title"`
+	MainText   string            `json:"main_text"`
+	CodeBlocks []CodeBlock       `json:"code_blocks,omitempty"`
+	Metadata   map[string]string `json:"metadata,omitempty"`
+}
+
+// GitHubFile represents a file from a GitHub repository
+type GitHubFile struct {
+	Path     string `json:"path"`
+	Content  string `json:"content"`
+	Language string `json:"language,omitempty"`
+	Size     int    `json:"size"`
+	SHA      string `json:"sha"`
+	URL      string `json:"url"`
+}
+
+// GitHubEntry represents a file or directory in a GitHub repository
+type GitHubEntry struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+	Type string `json:"type"` // "file" or "dir"
+	Size int    `json:"size,omitempty"`
+	SHA  string `json:"sha"`
+	URL  string `json:"url"`
+}
+
+// GitHubSearchResult represents a code search result from GitHub
+type GitHubSearchResult struct {
+	Repository string `json:"repository"`
+	Path       string `json:"path"`
+	SHA        string `json:"sha"`
+	URL        string `json:"url"`
+	Fragment   string `json:"fragment,omitempty"`
+}
+
+// GitHubSearchOpts contains options for GitHub code search
+type GitHubSearchOpts struct {
+	Language string `json:"language,omitempty"`
+	Repo     string `json:"repo,omitempty"`
+	Path     string `json:"path,omitempty"`
+	PerPage  int    `json:"per_page,omitempty"`
+}
+
+// Gist represents a GitHub gist
+type Gist struct {
+	ID          string            `json:"id"`
+	Description string            `json:"description"`
+	Public      bool              `json:"public"`
+	Files       map[string]string `json:"files"` // filename -> content
+	URL         string            `json:"url"`
+	CreatedAt   time.Time         `json:"created_at"`
+}
+
+// GitLabFile represents a file from a GitLab repository
+type GitLabFile struct {
+	Path     string `json:"path"`
+	Content  string `json:"content"`
+	Language string `json:"language,omitempty"`
+	Size     int    `json:"size"`
+	BlobID   string `json:"blob_id"`
+	URL      string `json:"url"`
+}
+
+// GitLabSearchOpts contains options for GitLab code search
+type GitLabSearchOpts struct {
+	Scope   string `json:"scope,omitempty"` // blobs, commits, etc.
+	PerPage int    `json:"per_page,omitempty"`
+}
+
+// GitLabSearchResult represents a code search result from GitLab
+type GitLabSearchResult struct {
+	Project  string `json:"project"`
+	Path     string `json:"path"`
+	Ref      string `json:"ref"`
+	URL      string `json:"url"`
+	Fragment string `json:"fragment,omitempty"`
+}
+
+// SOQuestion represents a Stack Overflow question
+type SOQuestion struct {
+	ID           int        `json:"id"`
+	Title        string     `json:"title"`
+	Body         string     `json:"body"`
+	BodyMarkdown string     `json:"body_markdown,omitempty"`
+	Tags         []string   `json:"tags"`
+	Score        int        `json:"score"`
+	Answers      []SOAnswer `json:"answers,omitempty"`
+	AcceptedID   *int       `json:"accepted_id,omitempty"`
+	URL          string     `json:"url"`
+	CreatedAt    time.Time  `json:"created_at"`
+}
+
+// SOAnswer represents a Stack Overflow answer
+type SOAnswer struct {
+	ID           int         `json:"id"`
+	Body         string      `json:"body"`
+	BodyMarkdown string      `json:"body_markdown,omitempty"`
+	CodeBlocks   []CodeBlock `json:"code_blocks,omitempty"`
+	Score        int         `json:"score"`
+	IsAccepted   bool        `json:"is_accepted"`
+	URL          string      `json:"url"`
+}
+
+// SOSearchResult represents a Stack Overflow search result
+type SOSearchResult struct {
+	ID        int      `json:"id"`
+	Title     string   `json:"title"`
+	Tags      []string `json:"tags"`
+	Score     int      `json:"score"`
+	Answers   int      `json:"answers"`
+	URL       string   `json:"url"`
+	IsAnswerd bool     `json:"is_answered"`
+}
+
+// DocsPage represents a documentation page
+type DocsPage struct {
+	Title       string      `json:"title"`
+	Content     string      `json:"content"`
+	CodeBlocks  []CodeBlock `json:"code_blocks,omitempty"`
+	Sections    []string    `json:"sections,omitempty"`
+	Breadcrumbs []Link      `json:"breadcrumbs,omitempty"`
+	URL         string      `json:"url"`
+}
+
+// AgentResponse formats responses for easy agent consumption
+type AgentResponse struct {
+	Success     bool                   `json:"success"`
+	Source      string                 `json:"source"`       // URL or search engine
+	ContentType string                 `json:"content_type"` // text, code, mixed
+	Summary     string                 `json:"summary"`      // Brief summary for context
+	Content     string                 `json:"content"`      // Main content
+	CodeBlocks  []AgentCodeBlock       `json:"code_blocks,omitempty"`
+	Links       []AgentLink            `json:"links,omitempty"`
+	Metadata    map[string]interface{} `json:"metadata,omitempty"`
+	CachedAt    *time.Time             `json:"cached_at,omitempty"`
+}
+
+// AgentCodeBlock is a simplified code block for agent responses
+type AgentCodeBlock struct {
+	Language    string `json:"language"`
+	Code        string `json:"code"`
+	Description string `json:"description,omitempty"`
+	Source      string `json:"source,omitempty"` // File path or URL
+}
+
+// AgentLink is a simplified link for agent responses
+type AgentLink struct {
+	Text string `json:"text"`
+	URL  string `json:"url"`
+	Type string `json:"type,omitempty"` // documentation, source, reference
+}
+
+// ErrorType represents the type of scraping error
+type ErrorType string
+
+const (
+	ErrRateLimited  ErrorType = "rate_limited"
+	ErrNotFound     ErrorType = "not_found"
+	ErrAccessDenied ErrorType = "access_denied"
+	ErrTimeout      ErrorType = "timeout"
+	ErrInvalidURL   ErrorType = "invalid_url"
+	ErrParseFailure ErrorType = "parse_failure"
+	ErrNetwork      ErrorType = "network_error"
+)
+
+// ScrapeError represents a scraping error with context for agents
+type ScrapeError struct {
+	Type       ErrorType `json:"type"`
+	Message    string    `json:"message"`
+	StatusCode int       `json:"status_code,omitempty"`
+	Retryable  bool      `json:"retryable"`
+	Suggestion string    `json:"suggestion"` // What agent should do
+}
+
+func (e *ScrapeError) Error() string {
+	return e.Message
+}
+
+// ForAgent returns a user-friendly error message for the agent
+func (e *ScrapeError) ForAgent() string {
+	switch e.Type {
+	case ErrRateLimited:
+		return "Rate limited. Try again in a few seconds or use cached version."
+	case ErrNotFound:
+		return "Page not found. Verify the URL is correct."
+	case ErrAccessDenied:
+		return "Access denied. This may be a private resource."
+	case ErrTimeout:
+		return "Request timed out. The server may be slow or unresponsive."
+	case ErrInvalidURL:
+		return "Invalid URL format. Please check the URL."
+	case ErrParseFailure:
+		return "Failed to parse page content. The page format may be unsupported."
+	case ErrNetwork:
+		return "Network error. Check connectivity and try again."
+	default:
+		return e.Message
+	}
+}
+
+// CacheEntry represents a cached fetch result
+type CacheEntry struct {
+	ID          string    `json:"id"`
+	URLHash     string    `json:"url_hash"`
+	URL         string    `json:"url"`
+	ContentType string    `json:"content_type"`
+	RawContent  string    `json:"raw_content"`
+	CleanText   string    `json:"clean_text"`
+	CodeBlocks  []byte    `json:"code_blocks"` // JSON-encoded
+	Metadata    []byte    `json:"metadata"`    // JSON-encoded
+	FetchedAt   time.Time `json:"fetched_at"`
+	ExpiresAt   time.Time `json:"expires_at"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+// RateLimitConfig defines rate limit settings per domain
+type RateLimitConfig struct {
+	Domain         string        `json:"domain"`
+	RequestsPerSec float64       `json:"requests_per_sec"`
+	BurstSize      int           `json:"burst_size"`
+	RetryAfter     time.Duration `json:"retry_after,omitempty"`
+}
+
+// DefaultRateLimits provides default rate limits for common domains
+var DefaultRateLimits = map[string]float64{
+	"github.com":            10, // 10 req/s without auth
+	"api.github.com":        30, // With auth
+	"gitlab.com":            10,
+	"api.gitlab.com":        10,
+	"stackoverflow.com":     30, // SE API is generous
+	"api.stackexchange.com": 30,
+	"default":               2, // Conservative default
+}


### PR DESCRIPTION
This commit adds comprehensive web scraping capabilities to PedroCLI,
enabling agents to fetch current information from the web, pull code
examples from public repositories, and search for solutions on Q&A sites.

Components added:
- pkg/webscrape/: Core web scraping package
  - types.go: Type definitions for fetch results, code blocks, search results
  - fetcher.go: HTTP fetcher with caching and rate limiting
  - extractor.go: HTML content extraction (text, code blocks)
  - cache.go: Caching layer (SQLite or in-memory)
  - ratelimit.go: Per-domain rate limiting
  - search.go: Search engine integrations (DuckDuckGo, SearXNG)

- pkg/webscrape/handlers/: Site-specific handlers
  - github.go: GitHub API handler for files, repos, gists, code search
  - gitlab.go: GitLab API handler (supports self-hosted instances)
  - stackoverflow.go: Stack Exchange API handler for Q&A

- pkg/tools/webscrape.go: MCP tool wrapper exposing all handlers

MCP actions available:
- fetch_url: Fetch and extract content from any URL
- search_web: Web search using DuckDuckGo or SearXNG
- fetch_github_file/readme/directory: GitHub file operations
- search_github_code: GitHub code search
- fetch_gitlab_file/readme: GitLab file operations
- fetch_stackoverflow_question: Fetch SO questions with answers
- search_stackoverflow: Search Stack Overflow
- extract_code_from_url: Extract code blocks from web pages

Configuration: Added WebScrapingConfig to pkg/config/config.go with
settings for rate limits, caching, API tokens, and search engine preferences.

Documentation: Added comprehensive docs/webscraping-tool.md with
architecture, usage examples, and configuration reference.