### PR TITLE
Add podcast WebUI with voice dictation and Notion integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,8 @@ coverage.out
 .DS_Store
 
 # Job state directory
-/tmp/pedroceli-jobs/
+/tmp/pedrocli-jobs/
 
 # Config files (don't commit actual configs, only examples)
-.pedroceli.json
+.pedrocli.json
+.env

--- a/.pedrocli.json
+++ b/.pedrocli.json
@@ -5,6 +5,11 @@
     "context_size": 32768,
     "temperature": 0.2
   },
+  "voice": {
+    "enabled": true,
+    "whisper_url": "http://localhost:9090",
+    "language": "en"
+  },
   "project": {
     "name": "Taikai",
     "workdir": "/Users/miriahpeterson/Code/go-projects/taikai",
@@ -23,5 +28,19 @@
     "enabled": true,
     "keep_temp_files": true,
     "log_level": "info"
+  },
+  "podcast": {
+    "enabled": true,
+    "notion": {
+      "enabled": true,
+      "databases": {
+        "scripts": "29da4c9f98458041afaec55980124eb7"
+      }
+    },
+    "metadata": {
+      "name": "Domesticating AI",
+      "description": "A podcast about practical AI for developers",
+      "format": "weekly discussion"
+    }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,37 @@ make lint               # Run golangci-lint
 make tidy               # Tidy dependencies
 ```
 
+### Running the Web UI
+```bash
+# Start the HTTP server (includes MCP server)
+./pedrocli-http-server
+
+# Access at http://localhost:8080
+```
+
+### Running whisper.cpp (Voice Dictation)
+
+The web UI supports voice-to-text using whisper.cpp. To enable:
+
+1. **Start whisper.cpp server**:
+```bash
+# From whisper.cpp directory (e.g., ~/Code/ml/whisper.cpp)
+./build/bin/whisper-server -m models/ggml-base.en.bin --port 9090 --host 0.0.0.0
+```
+
+2. **Enable in config** (`.pedrocli.json`):
+```json
+{
+  "voice": {
+    "enabled": true,
+    "whisper_url": "http://localhost:9090",
+    "language": "en"
+  }
+}
+```
+
+3. **Restart HTTP server** - voice buttons will now work in the web UI.
+
 ## Core Architecture
 
 ### Two-Binary System

--- a/docs/WEBUI-GUIDE.md
+++ b/docs/WEBUI-GUIDE.md
@@ -1,0 +1,186 @@
+# PedroCLI Web UI Guide
+
+A quick-start guide for using the PedroCLI web interface.
+
+## Starting the Server
+
+```bash
+# Build (if needed)
+make build
+
+# Start the HTTP server
+./pedrocli-http-server
+```
+
+You should see:
+```
+🚀 PedroCLI HTTP Server v0.2.0-dev
+📡 Listening on http://0.0.0.0:8080
+🔧 MCP Server: Running
+```
+
+Open **http://localhost:8080** in your browser.
+
+## Using the Web UI
+
+### Coding Tools
+
+1. Click **Coding Tools** button (default)
+2. Select job type:
+   - **Builder** - Build new features from descriptions
+   - **Debugger** - Fix issues (provide symptoms + logs)
+   - **Reviewer** - Review code on a branch
+   - **Triager** - Diagnose issues without fixing
+3. Fill in the fields
+4. Click **Create Job**
+
+### Podcast Tools
+
+1. Click **Podcast Tools** button
+2. Select job type:
+   - **Create Script** - Generate episode script & outline
+   - **Add Link** - Add article/news to Notion for review
+   - **Add Guest** - Add guest info to Notion database
+   - **Review News** - Summarize news for episode prep
+3. Fill in the fields
+4. Click **Create Job**
+
+**Note**: Podcast tools require Notion integration. See [Podcast HOWTO](podcast/HOWTO.md).
+
+## Voice Dictation
+
+The web UI supports voice-to-text for filling in text fields using whisper.cpp.
+
+### Setup whisper.cpp
+
+1. **Install whisper.cpp**:
+   ```bash
+   git clone https://github.com/ggerganov/whisper.cpp
+   cd whisper.cpp
+   make
+   ```
+
+2. **Download a model**:
+   ```bash
+   # base.en is recommended for English (good balance of speed/accuracy)
+   bash ./models/download-ggml-model.sh base.en
+   ```
+
+3. **Start the whisper.cpp server**:
+   ```bash
+   ./server -m models/ggml-base.en.bin --port 9090 --host 0.0.0.0
+   ```
+
+### Enable Voice in PedroCLI
+
+Add to your `.pedrocli.json`:
+
+```json
+{
+  "voice": {
+    "enabled": true,
+    "whisper_url": "http://localhost:9090",
+    "language": "auto"
+  }
+}
+```
+
+### Using Voice
+
+1. Click the **Voice** button next to any text field
+2. Allow microphone access when prompted
+3. Speak your text
+4. Click **Stop** - the text will be transcribed and filled in
+
+**Model Options**:
+- `tiny` - Fastest, less accurate (~50MB)
+- `base` - Balanced (~150MB) **recommended**
+- `small` - Better accuracy (~500MB)
+- `medium`/`large` - Best accuracy, slower (>1GB)
+
+## Configuration Reference
+
+Full `.pedrocli.json` example:
+
+```json
+{
+  "model": {
+    "type": "ollama",
+    "model_name": "qwen2.5-coder:32b",
+    "temperature": 0.2
+  },
+  "project": {
+    "name": "MyProject",
+    "workdir": "/path/to/project"
+  },
+  "web": {
+    "enabled": true,
+    "port": 8080,
+    "host": "0.0.0.0"
+  },
+  "voice": {
+    "enabled": true,
+    "whisper_url": "http://localhost:9090",
+    "language": "auto"
+  },
+  "podcast": {
+    "enabled": true,
+    "notion": {
+      "enabled": true,
+      "databases": {
+        "scripts": "YOUR_EPISODE_DB_ID",
+        "articles_review": "YOUR_ARTICLES_DB_ID",
+        "guests": "YOUR_GUESTS_DB_ID"
+      }
+    }
+  }
+}
+```
+
+## Quick Start Checklist
+
+### Coding Jobs Only
+- [ ] Run `./pedrocli-http-server`
+- [ ] Open http://localhost:8080
+- [ ] Have Ollama running with your model
+
+### Podcast Jobs
+- [ ] Configure Notion databases in `.pedrocli.json`
+- [ ] Store Notion token (see [Podcast HOWTO](podcast/HOWTO.md))
+- [ ] Run `./pedrocli-http-server`
+- [ ] Click **Podcast Tools** in the web UI
+
+### Voice Dictation
+- [ ] Install and build whisper.cpp
+- [ ] Download a model (base.en recommended)
+- [ ] Start whisper.cpp server on port 9090
+- [ ] Add `voice` config to `.pedrocli.json`
+- [ ] Restart `./pedrocli-http-server`
+- [ ] Click **Voice** button to dictate
+
+## Troubleshooting
+
+### "Voice transcription is not enabled"
+1. Check whisper.cpp is running: `curl http://localhost:9090/health`
+2. Verify `voice.enabled: true` in config
+3. Restart the HTTP server
+
+### Jobs not appearing
+1. Check MCP server started (look for "🔧 MCP Server: Running")
+2. Click **Refresh** in Active Jobs
+3. Check browser console for errors
+
+### Notion errors
+1. Verify token is stored correctly
+2. Check database is shared with your integration
+3. See [Podcast HOWTO](podcast/HOWTO.md) for detailed setup
+
+## Remote Access (Tailscale)
+
+The server binds to `0.0.0.0:8080` by default, making it accessible via Tailscale:
+
+```
+http://<your-tailscale-ip>:8080
+```
+
+This allows you to use the web UI from your phone or other devices on your Tailscale network.

--- a/docs/podcast/HOWTO.md
+++ b/docs/podcast/HOWTO.md
@@ -53,21 +53,26 @@ Add your Notion configuration to `.pedrocli.json`:
 
 ### 3. Store Notion Token
 
-Store your Notion token securely in the token database:
+Store your Notion token securely using one of these methods:
 
 ```bash
-# Manual storage (for testing):
-echo "your_token_here" > /tmp/notion_token.txt
+# Option 1: Environment variable (supports 1Password CLI)
+export NOTION_TOKEN="your_token_here"
+# Or with op run:
+op run --env-file=.env -- ./pedrocli-http-server
 
-# Or use the OAuth storage system (recommended):
+# Option 2: Config file
+# Add to .pedrocli.json: "podcast.notion.api_key": "your_token_here"
+
+# Option 3: Token storage system (for OAuth flows)
 # pedrocli will prompt for tokens when needed
 ```
 
 ## Commands
 
-### Create a Podcast Script
+### Create a Podcast Script & Outline
 
-Create a structured episode script for your podcast:
+Create a structured episode script and outline for your podcast:
 
 ```bash
 ./pedrocli podcast create-script \
@@ -127,16 +132,6 @@ Add guest information to your podcast guests database:
 - Fills in name, bio, email, and other provided fields
 - Sets status to "Potential"
 
-### Create an Episode Outline
-
-Generate a high-level outline without full script details:
-
-```bash
-./pedrocli podcast create-outline \
-  -topic "Kubernetes Basics" \
-  -duration "45min"
-```
-
 ### Review News Items
 
 Summarize recent news for episode prep:
@@ -172,7 +167,7 @@ The "Episode Planner" (aka "scripts") database should have these properties:
 ### Common Issues
 
 **Problem**: "Notion API key not configured"
-- **Solution**: Store your token using the token storage system or in `/tmp/notion_token.txt` for testing
+- **Solution**: Set NOTION_TOKEN env var, add podcast.notion.api_key to config, or use token storage
 
 **Problem**: "Could not find property with name or id: Status"
 - **Solution**: The property is called "Status 🎛" (with emoji). Ensure your database has this exact property name.
@@ -204,7 +199,7 @@ Test your Notion connection directly:
 ```bash
 # Query a database
 curl -X POST "https://api.notion.com/v1/databases/<DB_ID>/query" \
-  -H "Authorization: Bearer $(cat /tmp/notion_token.txt)" \
+  -H "Authorization: Bearer $NOTION_TOKEN" \
   -H "Notion-Version: 2022-06-28" \
   -H "Content-Type: application/json"
 ```

--- a/pkg/voice/converter.go
+++ b/pkg/voice/converter.go
@@ -1,0 +1,77 @@
+package voice
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// ConvertToWav converts audio from any format to WAV using ffmpeg
+// This is needed because whisper.cpp only accepts WAV format
+func ConvertToWav(ctx context.Context, audioData []byte, inputFormat string) ([]byte, error) {
+	// Check if ffmpeg is available
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		return nil, fmt.Errorf("ffmpeg not found: %w (install with: brew install ffmpeg)", err)
+	}
+
+	// Create temp directory for conversion
+	tmpDir, err := os.MkdirTemp("", "voice-convert-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Write input file
+	inputPath := filepath.Join(tmpDir, "input."+inputFormat)
+	if err := os.WriteFile(inputPath, audioData, 0644); err != nil {
+		return nil, fmt.Errorf("failed to write input file: %w", err)
+	}
+
+	// Output path
+	outputPath := filepath.Join(tmpDir, "output.wav")
+
+	// Run ffmpeg to convert to wav
+	// -y: overwrite output
+	// -i: input file
+	// -ar 16000: sample rate (whisper expects 16kHz)
+	// -ac 1: mono channel
+	// -c:a pcm_s16le: 16-bit PCM encoding
+	cmd := exec.CommandContext(ctx, "ffmpeg",
+		"-y",
+		"-i", inputPath,
+		"-ar", "16000",
+		"-ac", "1",
+		"-c:a", "pcm_s16le",
+		outputPath,
+	)
+
+	// Capture stderr for error messages
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("ffmpeg conversion failed: %w\nstderr: %s", err, stderr.String())
+	}
+
+	// Read converted file
+	wavData, err := os.ReadFile(outputPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read converted file: %w", err)
+	}
+
+	return wavData, nil
+}
+
+// NeedsConversion checks if the audio format needs conversion to wav
+func NeedsConversion(format string) bool {
+	switch format {
+	case "wav", "wave":
+		return false
+	default:
+		// webm, mp3, ogg, etc. all need conversion
+		return true
+	}
+}

--- a/pkg/web/templates/components/job_card.html
+++ b/pkg/web/templates/components/job_card.html
@@ -5,10 +5,16 @@
             <!-- Job header -->
             <div class="flex items-center space-x-3 mb-2">
                 <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium
-                    {{if eq .type "builder"}}bg-blue-100 text-blue-800{{end}}
-                    {{if eq .type "debugger"}}bg-red-100 text-red-800{{end}}
-                    {{if eq .type "reviewer"}}bg-purple-100 text-purple-800{{end}}
-                    {{if eq .type "triager"}}bg-yellow-100 text-yellow-800{{end}}">
+                    {{if eq .type "builder"}}bg-blue-100 text-blue-800
+                    {{else if eq .type "debugger"}}bg-red-100 text-red-800
+                    {{else if eq .type "reviewer"}}bg-purple-100 text-purple-800
+                    {{else if eq .type "triager"}}bg-yellow-100 text-yellow-800
+                    {{else if eq .type "create_podcast_script"}}bg-green-100 text-green-800
+                    {{else if eq .type "add_notion_link"}}bg-indigo-100 text-indigo-800
+                    {{else if eq .type "add_guest"}}bg-pink-100 text-pink-800
+                    {{else if eq .type "create_episode_outline"}}bg-teal-100 text-teal-800
+                    {{else if eq .type "review_news_summary"}}bg-orange-100 text-orange-800
+                    {{else}}bg-gray-100 text-gray-800{{end}}">
                     {{.type}}
                 </span>
 

--- a/pkg/web/templates/index.html
+++ b/pkg/web/templates/index.html
@@ -54,10 +54,9 @@
                                 name="type"
                                 class="podcast-mode-only hidden w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500"
                                 onchange="updateFormFields(this.value)">
-                            <option value="create_podcast_script">Create Script - Generate episode scripts</option>
+                            <option value="create_podcast_script">Create Script - Generate episode script & outline</option>
                             <option value="add_notion_link">Add Link - Add article/news to review</option>
                             <option value="add_guest">Add Guest - Add guest information</option>
-                            <option value="create_episode_outline">Create Outline - Generate episode structure</option>
                             <option value="review_news_summary">Review News - Summarize news for prep</option>
                         </select>
                     </div>
@@ -137,9 +136,22 @@
 
                     <!-- Podcast: Topic field -->
                     <div id="topic-field" class="hidden">
-                        <label for="topic" class="block text-sm font-medium text-gray-700 mb-2">
-                            Episode Topic
-                        </label>
+                        <div class="flex items-center justify-between mb-2">
+                            <label for="topic" class="block text-sm font-medium text-gray-700">
+                                Episode Topic
+                            </label>
+                            <!-- Voice input button -->
+                            <button type="button"
+                                    id="voice-btn-topic"
+                                    onclick="VoiceRecorder.toggle('topic')"
+                                    class="voice-btn inline-flex items-center px-3 py-1 text-sm bg-gray-200 hover:bg-gray-300 rounded-md transition-colors">
+                                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                                    <path d="M7 4a3 3 0 016 0v6a3 3 0 11-6 0V4z"/>
+                                    <path d="M5.5 9.643a.75.75 0 00-1.5 0V10c0 3.06 2.29 5.585 5.25 5.954V17.5h-1.5a.75.75 0 000 1.5h4.5a.75.75 0 000-1.5h-1.5v-1.546A6.001 6.001 0 0016 10v-.357a.75.75 0 00-1.5 0V10a4.5 4.5 0 01-9 0v-.357z"/>
+                                </svg>
+                                <span class="ml-2">Voice</span>
+                            </button>
+                        </div>
                         <textarea id="topic"
                                   name="topic"
                                   rows="3"
@@ -149,9 +161,22 @@
 
                     <!-- Podcast: Notes field -->
                     <div id="notes-field" class="hidden">
-                        <label for="notes" class="block text-sm font-medium text-gray-700 mb-2">
-                            Notes (optional)
-                        </label>
+                        <div class="flex items-center justify-between mb-2">
+                            <label for="notes" class="block text-sm font-medium text-gray-700">
+                                Notes (optional)
+                            </label>
+                            <!-- Voice input button -->
+                            <button type="button"
+                                    id="voice-btn-notes"
+                                    onclick="VoiceRecorder.toggle('notes')"
+                                    class="voice-btn inline-flex items-center px-3 py-1 text-sm bg-gray-200 hover:bg-gray-300 rounded-md transition-colors">
+                                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                                    <path d="M7 4a3 3 0 016 0v6a3 3 0 11-6 0V4z"/>
+                                    <path d="M5.5 9.643a.75.75 0 00-1.5 0V10c0 3.06 2.29 5.585 5.25 5.954V17.5h-1.5a.75.75 0 000 1.5h4.5a.75.75 0 000-1.5h-1.5v-1.546A6.001 6.001 0 0016 10v-.357a.75.75 0 00-1.5 0V10a4.5 4.5 0 01-9 0v-.357z"/>
+                                </svg>
+                                <span class="ml-2">Voice</span>
+                            </button>
+                        </div>
                         <textarea id="notes"
                                   name="notes"
                                   rows="2"
@@ -185,9 +210,22 @@
 
                     <!-- Podcast: Guest Bio field -->
                     <div id="guest-bio-field" class="hidden">
-                        <label for="guest-bio" class="block text-sm font-medium text-gray-700 mb-2">
-                            Guest Bio
-                        </label>
+                        <div class="flex items-center justify-between mb-2">
+                            <label for="guest-bio" class="block text-sm font-medium text-gray-700">
+                                Guest Bio
+                            </label>
+                            <!-- Voice input button -->
+                            <button type="button"
+                                    id="voice-btn-bio"
+                                    onclick="VoiceRecorder.toggle('guest-bio')"
+                                    class="voice-btn inline-flex items-center px-3 py-1 text-sm bg-gray-200 hover:bg-gray-300 rounded-md transition-colors">
+                                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                                    <path d="M7 4a3 3 0 016 0v6a3 3 0 11-6 0V4z"/>
+                                    <path d="M5.5 9.643a.75.75 0 00-1.5 0V10c0 3.06 2.29 5.585 5.25 5.954V17.5h-1.5a.75.75 0 000 1.5h4.5a.75.75 0 000-1.5h-1.5v-1.546A6.001 6.001 0 0016 10v-.357a.75.75 0 00-1.5 0V10a4.5 4.5 0 01-9 0v-.357z"/>
+                                </svg>
+                                <span class="ml-2">Voice</span>
+                            </button>
+                        </div>
                         <textarea id="guest-bio"
                                   name="bio"
                                   rows="2"
@@ -365,10 +403,6 @@ function updateFormFields(type) {
             document.getElementById('guest-name-field').classList.remove('hidden');
             document.getElementById('guest-bio-field').classList.remove('hidden');
             document.getElementById('guest-email-field').classList.remove('hidden');
-            break;
-        case 'create_episode_outline':
-            document.getElementById('topic-field').classList.remove('hidden');
-            document.getElementById('notes-field').classList.remove('hidden');
             break;
         case 'review_news_summary':
             document.getElementById('focus-topic-field').classList.remove('hidden');


### PR DESCRIPTION
Features:
- Add podcast job types to WebUI (create script, add link, add guest, review news)
- Add voice dictation buttons using whisper.cpp for text input
- Add ffmpeg audio conversion (webm → wav) for whisper.cpp compatibility
- Add NOTION_TOKEN env var support for 1Password CLI (op run)
- Fix MCP client race condition for concurrent requests

Technical changes:
- pkg/httpbridge/handlers.go: Add podcast job form handling
- pkg/httpbridge/voice_handlers.go: Add audio format conversion
- pkg/voice/converter.go: New ffmpeg-based audio converter
- pkg/mcp/client.go: Fix race condition with proper mutex locking
- pkg/tools/notion.go: Add env var fallback for API key
- pkg/web/static/js/voice.js: Handle multiple voice buttons, fix stale streams
- pkg/web/templates/index.html: Add podcast tools UI with voice buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)