### PR TITLE
feat: Migrate CLI from file-based jobs.Manager to DBManager

### DIFF
--- a/cmd/pedrocli/setup.go
+++ b/cmd/pedrocli/setup.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"context"
+	"log"
 	"os"
 
 	"github.com/soypete/pedrocli/pkg/agents"
 	"github.com/soypete/pedrocli/pkg/config"
+	"github.com/soypete/pedrocli/pkg/database"
 	"github.com/soypete/pedrocli/pkg/jobs"
 	"github.com/soypete/pedrocli/pkg/llm"
+	"github.com/soypete/pedrocli/pkg/storage"
 	"github.com/soypete/pedrocli/pkg/tools"
 )
 
@@ -14,7 +18,8 @@ import (
 type AppContext struct {
 	Config     *config.Config
 	Backend    llm.Backend
-	JobManager *jobs.Manager
+	JobManager jobs.JobManager
+	Database   *database.DB
 	WorkDir    string
 
 	// Tools
@@ -32,7 +37,7 @@ type AppContext struct {
 	BlogNotionTool  tools.Tool
 }
 
-// NewAppContext creates and initializes the application context
+// NewAppContext creates and initializes the application context with database-backed job manager.
 func NewAppContext(cfg *config.Config) (*AppContext, error) {
 	// Create LLM backend
 	backend, err := llm.NewBackend(cfg)
@@ -40,10 +45,30 @@ func NewAppContext(cfg *config.Config) (*AppContext, error) {
 		return nil, err
 	}
 
-	// Create job manager
-	jobManager, err := jobs.NewManager("/tmp/pedrocli-jobs")
+	// Create database connection
+	dbCfg := database.DefaultConfig()
+	db, err := database.New(dbCfg)
 	if err != nil {
 		return nil, err
+	}
+
+	// Run migrations
+	ctx := context.Background()
+	if err := db.Migrate(ctx); err != nil {
+		db.Close()
+		return nil, err
+	}
+
+	// Create job store and manager
+	jobStore := storage.NewJobStore(db.DB)
+	jobManager := jobs.NewDBManager(jobStore)
+
+	// Migrate existing file-based jobs to database
+	migrated, err := jobManager.MigrateFromFiles(ctx, "/tmp/pedrocli-jobs")
+	if err != nil {
+		log.Printf("Warning: failed to migrate jobs from files: %v", err)
+	} else if migrated > 0 {
+		log.Printf("Migrated %d jobs from files to database", migrated)
 	}
 
 	// Get working directory
@@ -53,28 +78,37 @@ func NewAppContext(cfg *config.Config) (*AppContext, error) {
 	}
 
 	// Create tools
-	ctx := &AppContext{
+	appCtx := &AppContext{
 		Config:     cfg,
 		Backend:    backend,
 		JobManager: jobManager,
+		Database:   db,
 		WorkDir:    workDir,
 	}
 
 	// Initialize code tools
-	ctx.FileTool = tools.NewFileTool()
-	ctx.GitTool = tools.NewGitTool(workDir)
-	ctx.BashTool = tools.NewBashTool(cfg, workDir)
-	ctx.TestTool = tools.NewTestTool(workDir)
-	ctx.CodeEditTool = tools.NewCodeEditTool()
-	ctx.SearchTool = tools.NewSearchTool(workDir)
-	ctx.NavigateTool = tools.NewNavigateTool(workDir)
+	appCtx.FileTool = tools.NewFileTool()
+	appCtx.GitTool = tools.NewGitTool(workDir)
+	appCtx.BashTool = tools.NewBashTool(cfg, workDir)
+	appCtx.TestTool = tools.NewTestTool(workDir)
+	appCtx.CodeEditTool = tools.NewCodeEditTool()
+	appCtx.SearchTool = tools.NewSearchTool(workDir)
+	appCtx.NavigateTool = tools.NewNavigateTool(workDir)
 
 	// Initialize blog tools
-	ctx.RSSFeedTool = tools.NewRSSFeedTool(cfg)
-	ctx.StaticLinksTool = tools.NewStaticLinksTool(cfg)
-	ctx.BlogNotionTool = tools.NewBlogNotionTool(cfg)
+	appCtx.RSSFeedTool = tools.NewRSSFeedTool(cfg)
+	appCtx.StaticLinksTool = tools.NewStaticLinksTool(cfg)
+	appCtx.BlogNotionTool = tools.NewBlogNotionTool(cfg)
 
-	return ctx, nil
+	return appCtx, nil
+}
+
+// Close closes the database connection.
+func (ctx *AppContext) Close() error {
+	if ctx.Database != nil {
+		return ctx.Database.Close()
+	}
+	return nil
 }
 
 // registerCodeTools registers standard code tools with an agent


### PR DESCRIPTION
## Summary

Completes the job manager migration started in #28 by updating the CLI to use the database-backed `DBManager` instead of the deprecated file-based `Manager`.

## Changes

### `cmd/pedrocli/setup.go`
- Changed `JobManager` field from `*jobs.Manager` to `jobs.JobManager` interface
- Added `Database *database.DB` field
- Updated `NewAppContext()` to:
  - Create database connection with default config
  - Run migrations
  - Create `storage.JobStore` and `jobs.NewDBManager()`
  - Auto-migrate existing file-based jobs to database
- Added `Close()` method for proper cleanup

### `cmd/pedrocli/main.go`
- Updated `pollJobStatus()` to accept `jobs.JobManager` interface
- Updated `statusCommand()`, `listCommand()`, `cancelCommand()` to use `NewAppContext()` with `appCtx.JobManager`
- Added `defer appCtx.Close()` for proper cleanup

## Benefits

- CLI and HTTP server now share the same job storage (PostgreSQL/SQLite)
- Jobs created via CLI are visible in web UI and vice versa
- Existing file-based jobs are automatically migrated on first run
- Consistent job tracking across all entry points

## Test plan

- [x] Build succeeds
- [x] All tests pass
- [x] Lint passes
- [ ] Manual test: `pedrocli list` shows jobs from database
- [ ] Manual test: Jobs created via CLI appear in web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)