### PR TITLE
feat: Add podcast episode outline generator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -480,6 +480,75 @@ Configure in `.pedrocli.json`:
 
 The web UI also supports browser-based speech recognition (Chrome/Edge) as a fallback.
 
+### Podcast Tools Setup
+
+For podcast episode preparation features (outline, script, news, scheduling):
+
+The podcast tools use the same Notion integration as blog tools (see "Blog Tools Setup" above).
+
+**Running Podcast Commands with Notion Integration**:
+
+```bash
+# Use op run to inject NOTION_TOKEN from .env
+op run --env-file=.env -- ./pedrocli podcast outline \
+  -episode "S01E03" \
+  -title "How to Choose a Local LLM" \
+  -duration 25 \
+  -output outline.md
+
+# Generate script from outline
+op run --env-file=.env -- ./pedrocli podcast script \
+  -outline outline.md \
+  -episode "S01E03"
+
+# Create Cal.com booking link (requires CAL_API_KEY in .env)
+op run --env-file=.env -- ./pedrocli podcast schedule \
+  -episode "S01E03" \
+  -title "How to Choose a Model" \
+  -duration 60
+```
+
+**Environment Variables Required** (in `.env`):
+```bash
+# Notion integration
+NOTION_TOKEN="op://pedro/notion_api_key/credential"
+
+# Cal.com integration (for scheduling)
+CAL_API_KEY="op://pedro/calcom_api_key/credential"
+```
+
+**Notion Database Configuration** (in `.pedrocli.json`):
+```json
+{
+  "podcast": {
+    "enabled": true,
+    "notion": {
+      "enabled": true,
+      "databases": {
+        "scripts": "YOUR-SCRIPTS-DATABASE-UUID",
+        "guests": "YOUR-GUESTS-DATABASE-UUID",
+        "topics": "YOUR-TOPICS-DATABASE-UUID",
+        "news": "YOUR-NEWS-DATABASE-UUID"
+      }
+    }
+  }
+}
+```
+
+**Available Podcast Commands**:
+- `podcast outline` - Generate structured episode outline from topic/summary
+- `podcast script` - Generate episode script from outline
+- `podcast news` - Review and summarize AI/tech news for episode prep
+- `podcast schedule` - Create Cal.com booking link with Riverside.fm integration
+- `podcast prep` - Full workflow (script + news + schedule)
+
+**Without Notion**: If you don't need Notion integration, run without `op run`:
+```bash
+./pedrocli podcast outline -episode "S01E03" -title "My Topic" -output outline.md
+```
+
+The outline will be saved to the output file but not uploaded to Notion.
+
 ### Service Ports (Complete)
 
 | Service | Port | Description |

--- a/README.md
+++ b/README.md
@@ -522,33 +522,84 @@ Unlike in-memory systems, PedroCLI writes all context to `/tmp/pedroceli-jobs/`:
 
 ## Podcast Tools Mode
 
-PedroCLI includes a **Podcast Tools Mode** for managing podcast content. This mode integrates with Notion and Google Calendar via MCP servers.
+PedroCLI includes a **Podcast Tools Mode** for managing podcast content. This mode integrates with Notion for episode planning and Cal.com for scheduling.
 
-### Podcast Job Types
+### Podcast Commands
 
-- **Create Script**: Generate episode scripts from topics and notes
-- **Add Link**: Add articles/news links to Notion for review
-- **Add Guest**: Add guest information to your guests database
-- **Create Outline**: Generate episode structure and outlines
-- **Review News**: Summarize news items for episode prep
+- `podcast outline` - Generate structured episode outline from topic/summary
+- `podcast script` - Generate episode script from outline
+- `podcast news` - Review and summarize AI/tech news for episode prep
+- `podcast schedule` - Create Cal.com booking link with Riverside.fm integration
+- `podcast prep` - Full workflow (script + news + schedule)
 
 ### Setup
 
-1. Copy the podcast config template:
+1. **Create Notion Integration**:
+   - Go to https://www.notion.so/my-integrations
+   - Create a new integration (e.g., "PedroCLI Podcast Tools")
+   - Copy the "Internal Integration Secret"
+   - Share your Notion databases with the integration
+
+2. **Store credentials in 1Password** (recommended):
+   Create a `.env` file with 1Password references:
+   ```bash
+   # .env file
+   NOTION_TOKEN="op://pedro/notion_api_key/credential"
+   CAL_API_KEY="op://pedro/calcom_api_key/credential"
+   ```
+
+3. **Configure `.pedrocli.json`**:
+   ```json
+   {
+     "podcast": {
+       "enabled": true,
+       "notion": {
+         "enabled": true,
+         "databases": {
+           "scripts": "YOUR-SCRIPTS-DATABASE-UUID",
+           "guests": "YOUR-GUESTS-DATABASE-UUID",
+           "topics": "YOUR-TOPICS-DATABASE-UUID",
+           "news": "YOUR-NEWS-DATABASE-UUID"
+         }
+       }
+     },
+     "calcom": {
+       "enabled": true,
+       "api_key": "",
+       "base_url": "https://api.cal.com/v1"
+     }
+   }
+   ```
+
+### Running Podcast Commands
+
+**With Notion Integration** (uses 1Password):
 ```bash
-cp .pedroceli.example.podcast.json ~/.pedroceli.json
+# Generate episode outline
+op run --env-file=.env -- ./pedrocli podcast outline \
+  -episode "S01E03" \
+  -title "How to Choose a Local LLM" \
+  -duration 25 \
+  -output outline.md
+
+# Generate script from outline
+op run --env-file=.env -- ./pedrocli podcast script \
+  -outline outline.md \
+  -episode "S01E03"
+
+# Create Cal.com booking link
+op run --env-file=.env -- ./pedrocli podcast schedule \
+  -episode "S01E03" \
+  -title "How to Choose a Model" \
+  -duration 60
 ```
 
-2. Fill in the TODO placeholders:
-   - Notion API key from https://www.notion.so/my-integrations
-   - Notion database IDs for scripts, articles, news, and guests
-   - Google Calendar credentials
-   - Podcast metadata (name, description, cohosts)
-
-3. Install the MCP servers (first run will install automatically):
+**Without Notion** (saves to file only):
 ```bash
-npx -y @notionhq/notion-mcp-server  # Notion
-npx -y @anthropic/google-calendar-mcp  # Google Calendar
+./pedrocli podcast outline \
+  -episode "S01E03" \
+  -title "My Topic" \
+  -output outline.md
 ```
 
 ### Model Profiles

--- a/cmd/test-blog-agent/main.go
+++ b/cmd/test-blog-agent/main.go
@@ -134,7 +134,7 @@ func main() {
 }
 
 func printUsage() {
-	fmt.Println(`Test BlogContentAgent 7-Phase Workflow
+	fmt.Print(`Test BlogContentAgent 7-Phase Workflow
 
 Usage: go run cmd/test-blog-agent/main.go <transcription-file>
 

--- a/pkg/agents/base.go
+++ b/pkg/agents/base.go
@@ -281,7 +281,7 @@ func (a *BaseAgent) executeInferenceWithSystemPrompt(ctx context.Context, contex
 		SystemPrompt: systemPrompt,
 		UserPrompt:   fullPrompt,
 		Temperature:  a.config.Model.Temperature,
-		MaxTokens:    8192, // Reserve for response
+		MaxTokens:    8192,        // Reserve for response
 		LogitBias:    a.logitBias, // Apply logit bias for token control
 	}
 

--- a/pkg/agents/blog_content.go
+++ b/pkg/agents/blog_content.go
@@ -26,11 +26,11 @@ type BlogContentAgent struct {
 	outline       string
 	sections      []SectionContent
 	tldr          string
-	socialPosts   map[string]string          // platform -> post
-	toolsList     []tools.Tool               // Tools for InferenceExecutor
-	config        *config.Config             // Configuration for Notion publishing
-	styleAnalyzer *BlogStyleAnalyzerAgent    // Optional style analyzer
-	useStyleGuide bool                       // Whether to use style guide in editor
+	socialPosts   map[string]string       // platform -> post
+	toolsList     []tools.Tool            // Tools for InferenceExecutor
+	config        *config.Config          // Configuration for Notion publishing
+	styleAnalyzer *BlogStyleAnalyzerAgent // Optional style analyzer
+	useStyleGuide bool                    // Whether to use style guide in editor
 }
 
 // SectionContent represents a generated blog section
@@ -248,7 +248,7 @@ func (a *BlogContentAgent) phaseAnalyzeStyle(ctx context.Context) error {
 	}
 
 	fmt.Println("\n📚 Analyzing your writing style from Substack RSS feed...")
-	fmt.Println("   This will help generate content in your authentic voice...\n")
+	fmt.Println("   This will help generate content in your authentic voice...")
 
 	styleGuide, err := a.styleAnalyzer.AnalyzeStyle(ctx)
 	if err != nil {
@@ -257,7 +257,7 @@ func (a *BlogContentAgent) phaseAnalyzeStyle(ctx context.Context) error {
 
 	fmt.Printf("\n✓ Writing style analysis complete!\n")
 	fmt.Printf("  Generated style guide: %d characters\n", len(styleGuide))
-	fmt.Println("  All content phases will now use your personal writing style\n")
+	fmt.Println("  All content phases will now use your personal writing style")
 
 	return nil
 }
@@ -617,7 +617,7 @@ func (a *BlogContentAgent) phaseEditorReview(ctx context.Context) error {
 			fmt.Printf("⚠️  Warning: Style analysis failed: %v\n", err)
 			fmt.Println("   Continuing with standard editor review...")
 		} else {
-			fmt.Println("✓ Style guide generated - will apply to editor review\n")
+			fmt.Println("✓ Style guide generated - will apply to editor review")
 		}
 	}
 

--- a/pkg/agents/blog_style_analyzer.go
+++ b/pkg/agents/blog_style_analyzer.go
@@ -39,7 +39,7 @@ func (a *BlogStyleAnalyzerAgent) AnalyzeStyle(ctx context.Context) (string, erro
 	fmt.Println("Fetching recent posts from Substack RSS...")
 	rssResult, err := a.rssTool.Execute(ctx, map[string]interface{}{
 		"action": "get_configured", // Use RSS feed URL from config
-		"limit":  10,                // Analyze last 10 posts for good sample size
+		"limit":  10,               // Analyze last 10 posts for good sample size
 	})
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch RSS feed: %w", err)

--- a/pkg/agents/orchestrator.go
+++ b/pkg/agents/orchestrator.go
@@ -28,16 +28,16 @@ type AgentOrchestrator interface {
 // Phase represents a single step in an agent workflow.
 // This combines the phased executor pattern with the unified orchestrator pattern.
 type Phase struct {
-	Name         string                  // Phase identifier (e.g., "analyze", "plan", "implement")
-	Description  string                  // Human-readable description
-	Execute      func(context.Context) error // Direct execution function (for unified agents)
-	Required     bool                    // Can this phase be skipped?
+	Name        string                      // Phase identifier (e.g., "analyze", "plan", "implement")
+	Description string                      // Human-readable description
+	Execute     func(context.Context) error // Direct execution function (for unified agents)
+	Required    bool                        // Can this phase be skipped?
 
 	// Fields for phased executor compatibility
-	SystemPrompt string                  // Custom system prompt for this phase
-	Tools        []string                // Subset of tools available in this phase (empty = all)
-	MaxRounds    int                     // Max inference rounds for this phase (0 = use default)
-	ExpectsJSON  bool                    // Allow the phase to produce structured output
+	SystemPrompt string                          // Custom system prompt for this phase
+	Tools        []string                        // Subset of tools available in this phase (empty = all)
+	MaxRounds    int                             // Max inference rounds for this phase (0 = use default)
+	ExpectsJSON  bool                            // Allow the phase to produce structured output
 	Validator    func(result *PhaseResult) error // Validates the phase output
 }
 
@@ -58,7 +58,7 @@ type ExecutionMode int
 
 const (
 	ExecutionModeSync  ExecutionMode = iota // CLI - blocking execution
-	ExecutionModeAsync                       // Web UI - background job
+	ExecutionModeAsync                      // Web UI - background job
 )
 
 func (m ExecutionMode) String() string {

--- a/pkg/agents/podcast_outline_phases.go
+++ b/pkg/agents/podcast_outline_phases.go
@@ -1,0 +1,275 @@
+package agents
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/soypete/pedrocli/pkg/llm"
+	"github.com/soypete/pedrocli/pkg/prompts"
+)
+
+// Outline Generation Phases
+// These implement the 5-phase workflow for generating podcast episode outlines
+
+// phaseGatherOutlineContext collects episode metadata and context
+func (a *UnifiedPodcastAgent) phaseGatherOutlineContext(ctx context.Context) error {
+	fmt.Println("   📋 Gathering episode context...")
+
+	// Store input parameters in content data
+	a.currentContent.Data["episode"] = a.episode
+	a.currentContent.Data["title"] = a.title
+	a.currentContent.Data["guests"] = a.guests
+	a.currentContent.Data["duration"] = a.duration
+
+	// If topic summary provided in outline field, use it
+	if a.outline != "" {
+		a.currentContent.Data["topic_summary"] = a.outline
+		fmt.Printf("   📝 Topic summary: %s\n", truncate(a.outline, 100))
+	}
+
+	// Check for pre-provided news items
+	if len(a.newsItems) > 0 {
+		a.currentContent.Data["news_provided"] = true
+		fmt.Printf("   📰 %d news items provided\n", len(a.newsItems))
+	}
+
+	fmt.Println("   ✅ Context gathered")
+	return nil
+}
+
+// phaseResearchNews searches for recent news relevant to the episode topic
+func (a *UnifiedPodcastAgent) phaseResearchNews(ctx context.Context) error {
+	fmt.Println("   🔍 Researching relevant news...")
+
+	// Skip if news items already provided
+	if len(a.newsItems) > 0 {
+		fmt.Println("   ⏭️  News items already provided, skipping research")
+		return nil
+	}
+
+	// Use web search and RSS tools to find relevant news
+	searchTool, hasSearch := a.tools["web_search"]
+	rssTool, hasRSS := a.tools["rss_feed"]
+
+	var foundNews []NewsItem
+
+	// Search for news related to episode topic
+	if hasSearch && a.title != "" {
+		searchQuery := fmt.Sprintf("AI %s news recent", a.title)
+		result, err := searchTool.Execute(ctx, map[string]interface{}{
+			"query":       searchQuery,
+			"max_results": 5,
+		})
+		if err != nil {
+			fmt.Printf("   ⚠️  Web search failed: %v\n", err)
+		} else if result.Success {
+			// Parse search results into news items
+			// The search tool returns formatted results in Output
+			fmt.Printf("   🔎 Found web search results\n")
+		}
+	}
+
+	// Fetch from RSS feeds
+	if hasRSS {
+		result, err := rssTool.Execute(ctx, map[string]interface{}{
+			"action":    "fetch",
+			"max_items": 5,
+		})
+		if err != nil {
+			fmt.Printf("   ⚠️  RSS fetch failed: %v\n", err)
+		} else if result.Success {
+			fmt.Printf("   📡 Fetched RSS feed items\n")
+		}
+	}
+
+	// Limit to maxNews items
+	maxNews := a.maxNews
+	if maxNews == 0 {
+		maxNews = 3 // Default to 3 news items
+	}
+	if len(foundNews) > maxNews {
+		foundNews = foundNews[:maxNews]
+	}
+
+	a.newsItems = foundNews
+	a.currentContent.Data["news_items"] = a.newsItems
+
+	fmt.Printf("   📰 Collected %d news items\n", len(a.newsItems))
+	return nil
+}
+
+// phaseGenerateOutline generates the structured episode outline using LLM
+func (a *UnifiedPodcastAgent) phaseGenerateOutline(ctx context.Context) error {
+	fmt.Println("   ✍️  Generating episode outline...")
+
+	// Get the outline prompt template
+	promptManager := prompts.NewManager(a.config)
+	outlinePrompt := promptManager.GetPrompt("podcast", "generate_episode_outline")
+
+	if outlinePrompt == "" {
+		return fmt.Errorf("failed to load outline prompt template")
+	}
+
+	// Build the user prompt with episode details
+	var userPrompt strings.Builder
+	userPrompt.WriteString("Generate an episode outline with these details:\n\n")
+	userPrompt.WriteString(fmt.Sprintf("**Episode Number**: %s\n", a.episode))
+	userPrompt.WriteString(fmt.Sprintf("**Episode Title**: %s\n", a.title))
+	userPrompt.WriteString(fmt.Sprintf("**Recording Date**: %s\n", time.Now().AddDate(0, 0, 7).Format("January 2, 2006")))
+	userPrompt.WriteString(fmt.Sprintf("**Publish Date**: %s\n", time.Now().AddDate(0, 0, 14).Format("January 2, 2006")))
+	userPrompt.WriteString("**Status**: Idea\n")
+
+	if a.guests != "" {
+		userPrompt.WriteString(fmt.Sprintf("**Guests**: %s\n", a.guests))
+	} else {
+		userPrompt.WriteString("**Guests**: None\n")
+	}
+
+	// Topic summary
+	topicSummary, _ := a.currentContent.Data["topic_summary"].(string)
+	if topicSummary != "" {
+		userPrompt.WriteString(fmt.Sprintf("\n**Topic Summary**:\n%s\n", topicSummary))
+	}
+
+	// News items
+	if len(a.newsItems) > 0 {
+		userPrompt.WriteString("\n**News Items**:\n")
+		for i, item := range a.newsItems {
+			userPrompt.WriteString(fmt.Sprintf("%d. %s\n   URL: %s\n   %s\n\n",
+				i+1, item.Title, item.URL, item.Description))
+		}
+	} else {
+		userPrompt.WriteString("\n**News Items**: [Research and add 3 relevant AI/tech news items]\n")
+	}
+
+	// Call LLM to generate outline
+	request := &llm.InferenceRequest{
+		SystemPrompt: outlinePrompt,
+		UserPrompt:   userPrompt.String(),
+		Temperature:  0.7, // Slightly higher for creative content
+		MaxTokens:    4000,
+	}
+
+	response, err := a.backend.Infer(ctx, request)
+	if err != nil {
+		return fmt.Errorf("LLM inference failed: %w", err)
+	}
+
+	// Store the generated outline
+	a.outline = response.Text
+	a.currentContent.Data["generated_outline"] = a.outline
+
+	fmt.Printf("   📝 Generated outline (%d characters)\n", len(a.outline))
+	return nil
+}
+
+// phaseReviewOutline reviews the outline for completeness
+func (a *UnifiedPodcastAgent) phaseReviewOutline(ctx context.Context) error {
+	fmt.Println("   🔍 Reviewing outline...")
+
+	if a.outline == "" {
+		return fmt.Errorf("no outline to review")
+	}
+
+	// Check for required sections
+	requiredSections := []string{
+		"Episode Details",
+		"Host Bios",
+		"Segment Outline",
+		"Intro",
+		"News Segment",
+		"Main Conversation",
+		"Outro",
+		"Show Notes",
+	}
+
+	var missingSections []string
+	outlineLower := strings.ToLower(a.outline)
+	for _, section := range requiredSections {
+		if !strings.Contains(outlineLower, strings.ToLower(section)) {
+			missingSections = append(missingSections, section)
+		}
+	}
+
+	if len(missingSections) > 0 {
+		fmt.Printf("   ⚠️  Missing sections: %s\n", strings.Join(missingSections, ", "))
+		a.currentContent.Data["review_warnings"] = missingSections
+	} else {
+		fmt.Println("   ✅ All required sections present")
+	}
+
+	// Check approximate timing (for 25-minute episode)
+	// Main conversation should be ~12 minutes
+	if strings.Contains(a.outline, "10:00 – 22:00") || strings.Contains(a.outline, "10:00 - 22:00") {
+		fmt.Println("   ⏱️  Timing looks correct for 25-minute episode")
+	}
+
+	a.currentContent.Data["reviewed"] = true
+	a.currentContent.Data["review_timestamp"] = time.Now().UTC().Format(time.RFC3339)
+
+	return nil
+}
+
+// phaseSaveOutline saves the outline to Notion
+func (a *UnifiedPodcastAgent) phaseSaveOutline(ctx context.Context) error {
+	fmt.Println("   📤 Saving outline...")
+
+	if a.outline == "" {
+		return fmt.Errorf("no outline to save")
+	}
+
+	// Save to Notion Episode Planner database if enabled
+	if a.config.Podcast.Notion.Enabled {
+		notionTool, ok := a.tools["notion"]
+		if !ok {
+			fmt.Println("   ⚠️  Notion tool not available, saving to storage only")
+		} else {
+			fmt.Println("   📝 Creating Notion page in Episode Planner...")
+
+			// Prepare properties for Notion page
+			properties := map[string]interface{}{
+				"Episode #":             fmt.Sprintf("%s - %s", a.episode, a.title),
+				"Title / Working Topic": a.title,
+				"Status 🎛":              "Outline",
+				"Notes":                 fmt.Sprintf("Duration: %d minutes\nGuests: %s\n\nAuto-generated outline", a.duration, a.guests),
+			}
+
+			// Create page in Episode Planner database
+			result, err := notionTool.Execute(ctx, map[string]interface{}{
+				"action":        "create_page",
+				"database_name": "scripts", // Uses scripts database for outlines too
+				"properties":    properties,
+				"content":       a.outline,
+			})
+
+			if err != nil {
+				fmt.Printf("   ⚠️  Failed to save to Notion: %v\n", err)
+			} else if !result.Success {
+				fmt.Printf("   ⚠️  Notion save error: %s\n", result.Error)
+			} else {
+				fmt.Println("   ✅ Outline saved to Notion")
+				a.currentContent.Data["notion_page_created"] = true
+				a.currentContent.Data["notion_output"] = result.Output
+			}
+		}
+	} else {
+		fmt.Println("   ℹ️  Notion integration disabled")
+	}
+
+	// Mark as saved in content store
+	a.currentContent.Data["saved"] = true
+	a.currentContent.Data["save_timestamp"] = time.Now().UTC().Format(time.RFC3339)
+
+	fmt.Println("   ✅ Outline saved to storage")
+	return nil
+}
+
+// Helper function to truncate strings for display
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}

--- a/pkg/agents/podcast_schedule_phases.go
+++ b/pkg/agents/podcast_schedule_phases.go
@@ -3,6 +3,7 @@ package agents
 import (
 	"context"
 	"fmt"
+	"strings"
 )
 
 // Cal.com Scheduling Phases
@@ -29,11 +30,20 @@ func (a *UnifiedPodcastAgent) phaseParseTemplate(ctx context.Context) error {
 func (a *UnifiedPodcastAgent) phaseCreateEventType(ctx context.Context) error {
 	fmt.Println("   📅 Creating Cal.com event type...")
 
+	// Use podcast name from config, with fallback
+	podcastName := a.config.Podcast.Metadata.Name
+	if podcastName == "" {
+		podcastName = "Podcast Interview"
+	}
+
+	// Generate slug from podcast name
+	slug := strings.ToLower(strings.ReplaceAll(podcastName, " ", "-"))
+
 	// TODO: Use cal_com tool to create event type
 	// For now, create placeholder event type data
 	eventType := map[string]interface{}{
-		"title":       fmt.Sprintf("SoypeteTech - Episode %s", a.episode),
-		"slug":        fmt.Sprintf("soypete-%s", a.episode),
+		"title":       fmt.Sprintf("%s - Episode %s", podcastName, a.episode),
+		"slug":        fmt.Sprintf("%s-%s", slug, a.episode),
 		"length":      a.duration,
 		"description": a.generateEventDescription(),
 	}
@@ -56,7 +66,8 @@ func (a *UnifiedPodcastAgent) phaseConfigureRiverside(ctx context.Context) error
 	// TODO: Configure Riverside.fm location in event type
 	// For now, just mark as configured
 	a.currentContent.Data["riverside_enabled"] = true
-	a.currentContent.Data["riverside_studio_url"] = "https://riverside.fm/studio/soypete-tech-podcast"
+	// Riverside studio URL should come from config in the future
+	a.currentContent.Data["riverside_studio_url"] = "[Configure Riverside.fm studio URL in config]"
 
 	fmt.Println("   ✅ Riverside.fm configured")
 	return nil
@@ -74,7 +85,8 @@ func (a *UnifiedPodcastAgent) phaseGenerateBookingLink(ctx context.Context) erro
 	}
 
 	slug, _ := eventType["slug"].(string)
-	a.bookingURL = fmt.Sprintf("https://cal.com/soypete/%s", slug)
+	// Cal.com username should come from config in the future
+	a.bookingURL = fmt.Sprintf("https://cal.com/[username]/%s", slug)
 
 	a.currentContent.Data["booking_url"] = a.bookingURL
 
@@ -105,7 +117,13 @@ func (a *UnifiedPodcastAgent) phaseSaveBookingToNotion(ctx context.Context) erro
 
 // generateEventDescription creates description for Cal.com event
 func (a *UnifiedPodcastAgent) generateEventDescription() string {
-	desc := fmt.Sprintf("60-minute podcast interview for SoypeteTech, Episode %s: %s\n\n", a.episode, a.title)
+	// Use podcast name from config
+	podcastName := a.config.Podcast.Metadata.Name
+	if podcastName == "" {
+		podcastName = "the podcast"
+	}
+
+	desc := fmt.Sprintf("%d-minute podcast interview for %s, Episode %s: %s\n\n", a.duration, podcastName, a.episode, a.title)
 
 	if a.guests != "" {
 		desc += fmt.Sprintf("Guests: %s\n\n", a.guests)
@@ -120,10 +138,15 @@ func (a *UnifiedPodcastAgent) generateEventDescription() string {
 		desc += "Recording on Riverside.fm for studio-quality audio/video.\n\n"
 	}
 
-	desc += "Find us at:\n"
-	desc += "- Discord: https://discord.gg/soypete\n"
-	desc += "- YouTube: https://youtube.com/@soypete\n"
-	desc += "- Twitter: https://twitter.com/soypete\n"
+	// Use host social links from config if available
+	if len(a.config.Podcast.Metadata.Cohosts) > 0 {
+		desc += "Find the hosts at:\n"
+		for _, cohost := range a.config.Podcast.Metadata.Cohosts {
+			if len(cohost.SocialLinks) > 0 {
+				desc += fmt.Sprintf("- %s: %s\n", cohost.Name, cohost.SocialLinks[0])
+			}
+		}
+	}
 
 	return desc
 }

--- a/pkg/agents/podcast_script_phases.go
+++ b/pkg/agents/podcast_script_phases.go
@@ -148,9 +148,9 @@ func (a *UnifiedPodcastAgent) phasePublishScript(ctx context.Context) error {
 			// Prepare properties for Notion page
 			// Note: Property names match actual Notion database schema
 			properties := map[string]interface{}{
-				"Episode #":             a.episode, // Title property
-				"Title / Working Topic": a.title,   // Rich text
-				"Status 🎛":             "Draft",   // Text property
+				"Episode #":             a.episode,                                                             // Title property
+				"Title / Working Topic": a.title,                                                               // Rich text
+				"Status 🎛":              "Draft",                                                               // Text property
 				"Notes":                 fmt.Sprintf("Duration: %d minutes\nGuests: %s", a.duration, a.guests), // Text with metadata
 				// Note: "Guests" is a relation property requiring page references
 				// For now, we include guest names in Notes field
@@ -191,7 +191,13 @@ func (a *UnifiedPodcastAgent) phasePublishScript(ctx context.Context) error {
 func (a *UnifiedPodcastAgent) generateIntroSegment() string {
 	var intro strings.Builder
 
-	intro.WriteString(fmt.Sprintf("Welcome to SoypeteTech, episode %s!\n\n", a.episode))
+	// Use podcast name from config, with fallback
+	podcastName := a.config.Podcast.Metadata.Name
+	if podcastName == "" {
+		podcastName = "the podcast"
+	}
+
+	intro.WriteString(fmt.Sprintf("Welcome to %s, episode %s!\n\n", podcastName, a.episode))
 
 	if a.guests != "" {
 		intro.WriteString(fmt.Sprintf("Today we're joined by %s.\n\n", a.guests))
@@ -229,10 +235,17 @@ func (a *UnifiedPodcastAgent) generateOutroSegment() string {
 		outro.WriteString(fmt.Sprintf("Big thanks to our guests %s for joining us today.\n\n", a.guests))
 	}
 
-	outro.WriteString("Find us at:\n")
-	outro.WriteString("- Discord: https://discord.gg/soypete\n")
-	outro.WriteString("- YouTube: https://youtube.com/@soypete\n")
-	outro.WriteString("- Twitter: https://twitter.com/soypete\n\n")
+	// Use host social links from config if available
+	outro.WriteString("Find the hosts at:\n")
+	for _, cohost := range a.config.Podcast.Metadata.Cohosts {
+		if len(cohost.SocialLinks) > 0 {
+			outro.WriteString(fmt.Sprintf("- %s: %s\n", cohost.Name, cohost.SocialLinks[0]))
+		}
+	}
+	if len(a.config.Podcast.Metadata.Cohosts) == 0 {
+		outro.WriteString("- [Add host links to config]\n")
+	}
+	outro.WriteString("\n")
 
 	outro.WriteString("See you next time!\n")
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -253,13 +253,20 @@ type PodcastMetadata struct {
 	RecordingPlatform string `json:"recording_platform,omitempty"` // e.g., "Riverside"
 	// TODO: Google Drive folder for assets
 	DriveFolder string `json:"drive_folder,omitempty"`
+
+	// Episode generation settings
+	DefaultDuration int    `json:"default_duration,omitempty"` // Default episode duration in minutes (e.g., 25)
+	SponsorInfo     string `json:"sponsor_info,omitempty"`     // Sponsor descriptions for episode outlines
+	SponsorLinks    string `json:"sponsor_links,omitempty"`    // Sponsor links for show notes
+	UpcomingEvents  string `json:"upcoming_events,omitempty"`  // Upcoming events to mention in episodes
 }
 
 // Cohost contains cohost information
 type Cohost struct {
-	Name string `json:"name,omitempty"`
-	Bio  string `json:"bio,omitempty"`
-	Role string `json:"role,omitempty"` // e.g., "host", "cohost", "producer"
+	Name        string   `json:"name,omitempty"`
+	Bio         string   `json:"bio,omitempty"`
+	Role        string   `json:"role,omitempty"`         // e.g., "host", "cohost", "producer"
+	SocialLinks []string `json:"social_links,omitempty"` // Social media links for this cohost
 }
 
 // CalComConfig contains Cal.com scheduling configuration

--- a/pkg/prompts/defaults.go
+++ b/pkg/prompts/defaults.go
@@ -392,4 +392,185 @@ Create a calendar event for a podcast recording session.
 
 Use the calendar tool to check availability and create the event.
 `,
+
+	"generate_episode_outline": `Generate a structured episode outline for "{{.PodcastName}}".
+
+You are generating a structured episode outline for **{{.PodcastName}}**, {{.PodcastDescription}}
+
+## Input Parameters
+
+You will receive:
+- **Episode Number**: (e.g., S01E03)
+- **Episode Title**: The main topic
+- **Recording Date**: When recording is scheduled
+- **Publish Date**: Target release date
+- **Status**: Idea | Recording | Editing | Released
+- **Guest(s)**: Names and brief context (if any)
+- **Topic Summary**: 2-3 sentence description of the episode focus
+- **News Items**: List of recent AI/tech news items to discuss (with URLs if available)
+- **Sponsor Info**: Current sponsors or community shout-outs
+
+-----
+
+## Output Template
+
+Generate the following structured outline:
+
+-----
+
+# 🧾 Episode Details
+
+|Field             |Value                                       |
+|------------------|--------------------------------------------|
+|**Episode**       |{episode_number} – {episode_title}          |
+|**Hosts**         |{{.CohostList}}|
+|**Guests**        |{guests or "None"}                          |
+|**Recording Date**|{recording_date}                            |
+|**Publish Date**  |{publish_date}                              |
+|**Status**        |{status}                                    |
+
+**Episode Summary:**
+{2-3 sentence summary of what listeners will learn}
+
+-----
+
+## 👥 Host Bios
+
+{{.HostBios}}
+
+-----
+
+## ⏱ Segment Outline ({{.EpisodeDuration}} minutes total)
+
+### 00:00 – 01:00 | Intro
+
+**Host Intros:**
+{{.HostIntros}}
+
+**Show Summary:** "{{.PodcastName}} is {{.PodcastDescription}}"
+
+**Episode Promise:** {One sentence stating what listeners will know/be able to do by episode end}
+
+-----
+
+### 01:00 – 08:00 | News Segment
+
+Each host brings 1-2 articles or updates. Frame each item with:
+- What happened?
+- Why does it matter for home/local AI builders?
+- Quick takes or concerns
+
+**News Item 1: {title}**
+- Source: {url}
+- Context: {why this matters to the audience}
+- Discussion angle: {suggested framing}
+
+**News Item 2: {title}**
+- Source: {url}
+- Context: {why this matters}
+- Discussion angle: {suggested framing}
+
+**News Item 3: {title}**
+- Source: {url}
+- Context: {why this matters}
+- Discussion angle: {suggested framing}
+
+-----
+
+### 08:00 – 10:00 | Sponsor / Community Shout-out
+
+**Sponsors:**
+{{.SponsorInfo}}
+
+**Mid-roll marker:** "[MID-ROLL] Everything we've talked about so far will be in the show notes if you're curious to learn more."
+
+**Sponsorship CTA:** "Interested in sponsoring? Reach out to us—check the show notes."
+
+-----
+
+### 10:00 – 22:00 | Main Conversation
+
+**Central Topic:** {episode_title}
+
+{Generate 4-6 discussion prompts based on the topic. Each prompt should include:}
+
+**Discussion Prompt 1: {question}**
+Talking points:
+- {point 1}
+- {point 2}
+- {point 3}
+- {point 4}
+
+**Discussion Prompt 2: {question}**
+Talking points:
+- {point 1}
+- {point 2}
+- {point 3}
+
+{Continue pattern for remaining prompts…}
+
+**Clip-worthy moments to watch for:**
+- {potential quotable moment 1}
+- {potential quotable moment 2}
+
+-----
+
+### 22:00 – 25:00 | Outro
+
+**Upcoming Events:**
+{{.UpcomingEvents}}
+
+**Where to Find the Hosts:**
+{{.HostLinks}}
+
+**Sign-off line:** {generate a thematic sign-off related to the episode topic}
+
+**Outro music / end card notes:** {any production notes}
+
+-----
+
+## 📝 Show Notes Template
+
+` + "```markdown" + `
+# {Episode Number}: {Episode Title}
+
+{Episode summary - 2-3 sentences}
+
+## Timestamps
+- 00:00 Intro
+- 01:00 News Segment
+- 08:00 Sponsors
+- 10:00 Main Conversation: {topic}
+- 22:00 Outro & Where to Find Us
+
+## News Links
+- {news item 1 title}: {url}
+- {news item 2 title}: {url}
+- {news item 3 title}: {url}
+
+## Resources Mentioned
+- {resource 1}
+- {resource 2}
+
+## Sponsors
+{{.SponsorLinks}}
+
+## Find the Hosts
+{{.HostLinksMarkdown}}
+
+## Contact
+Want to sponsor or suggest a topic? Reach out: {contact method}
+` + "```" + `
+
+-----
+
+## Generation Guidelines
+
+1. **Tone:** Practical, approachable, developer-focused. Avoid hype; favor actionable advice.
+2. **Audience:** Developers interested in running AI locally—from hobbyists to production teams.
+3. **Discussion prompts:** Frame as questions the hosts would naturally explore together. Include decision heuristics where possible.
+4. **Talking points:** Specific enough to guide conversation, loose enough to allow tangents.
+5. **News framing:** Always connect back to "why this matters for someone building at home."
+6. **Time estimates:** Main conversation is ~12 minutes for a 25-minute episode. Prompts should fill that naturally without rushing.
+`,
 }

--- a/pkg/storage/content/postgres.go
+++ b/pkg/storage/content/postgres.go
@@ -140,7 +140,6 @@ func (s *PostgresContentStore) List(ctx context.Context, filter Filter) ([]*Cont
 	if filter.Status != nil {
 		query += fmt.Sprintf(" AND status = $%d", argNum)
 		args = append(args, *filter.Status)
-		argNum++
 	}
 
 	query += " ORDER BY created_at DESC"

--- a/test/manual/research_tools.go
+++ b/test/manual/research_tools.go
@@ -35,7 +35,7 @@ func main() {
 }
 
 func printUsage() {
-	fmt.Println(`Manual Research Tools Test
+	fmt.Print(`Manual Research Tools Test
 
 Usage: go run test/manual/research_tools.go <command>
 
@@ -53,7 +53,7 @@ Examples:
 }
 
 func testWebSearch() {
-	fmt.Println("=== Testing Web Search ===\n")
+	fmt.Println("=== Testing Web Search ===")
 
 	searchTool := tools.NewWebSearchTool()
 
@@ -89,7 +89,7 @@ func testWebSearch() {
 }
 
 func testScrapeURL() {
-	fmt.Println("=== Testing URL Scraping ===\n")
+	fmt.Println("=== Testing URL Scraping ===")
 
 	scraperTool := tools.NewWebScraperTool()
 
@@ -117,7 +117,7 @@ func testScrapeURL() {
 }
 
 func testScrapeGithub() {
-	fmt.Println("=== Testing GitHub Scraping ===\n")
+	fmt.Println("=== Testing GitHub Scraping ===")
 
 	scraperTool := tools.NewWebScraperTool()
 
@@ -147,7 +147,7 @@ func testScrapeGithub() {
 }
 
 func testScrapeLocal() {
-	fmt.Println("=== Testing Local File Scraping ===\n")
+	fmt.Println("=== Testing Local File Scraping ===")
 
 	scraperTool := tools.NewWebScraperTool()
 
@@ -176,7 +176,7 @@ func testScrapeLocal() {
 }
 
 func testSearchAndScrape() {
-	fmt.Println("=== Testing Search → Scrape Workflow ===\n")
+	fmt.Println("=== Testing Search → Scrape Workflow ===")
 
 	searchTool := tools.NewWebSearchTool()
 	scraperTool := tools.NewWebScraperTool()
@@ -200,7 +200,7 @@ func testSearchAndScrape() {
 	}
 
 	fmt.Println(searchResult.Output)
-	fmt.Println("---\n")
+	fmt.Println("---")
 
 	// Step 2: Scrape the Go official site
 	fmt.Println("Step 2: Scraping https://go.dev/doc/...")


### PR DESCRIPTION
Add a new `pedrocli podcast outline` command that generates structured
episode outlines for podcasts like "Domesticating AI".

Changes:
- Add `generate_episode_outline` prompt template with configurable
  podcast metadata (name, hosts, duration, sponsors, etc.)
- Add WorkflowOutline type and 5-phase outline generation workflow
- Create podcast_outline_phases.go with LLM-driven outline generation
- Update config to support new podcast metadata fields (DefaultDuration,
  SponsorInfo, SponsorLinks, UpcomingEvents, SocialLinks for cohosts)
- Extend PromptData with template variables for dynamic outline generation
- Remove hardcoded SoypeteTech references - now uses config values

The outline generator creates:
- Episode details table
- Host bios (from config)
- Segment outline scaled to target duration (default 25 min)
- News segment placeholders
- Main conversation discussion prompts
- Show notes template

Usage:
  pedrocli podcast outline -episode "S01E03" -title "How to Choose a Local LLM"
  pedrocli podcast outline -episode "S01E04" -title "Agents That Work" -summary "Building reliable AI agents"