### PR TITLE
Add GitHub tool with API client and tests

### DIFF
--- a/cmd/pedrocli/main.go
+++ b/cmd/pedrocli/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"os/signal"
@@ -681,7 +682,9 @@ func runBlogInBackground(cfg *config.Config, transcription, title string) {
 		"job_dir":    jobDir,
 	}
 	metaJSON, _ := json.Marshal(jobMeta)
-	os.WriteFile(jobDir+"/meta.json", metaJSON, 0644)
+	if err := os.WriteFile(jobDir+"/meta.json", metaJSON, 0644); err != nil {
+		log.Printf("failed to write meta.json: %v", err)
+	}
 
 	fmt.Printf("📝 Blog job started in background: %s\n", jobID)
 	fmt.Printf("   Job directory: %s\n", jobDir)
@@ -748,11 +751,15 @@ func runBlogInBackground(cfg *config.Config, transcription, title string) {
 			jobMeta["error"] = err.Error()
 		}
 		metaJSON, _ = json.Marshal(jobMeta)
-		os.WriteFile(jobDir+"/meta.json", metaJSON, 0644)
+		if err := os.WriteFile(jobDir+"/meta.json", metaJSON, 0644); err != nil {
+			log.Printf("failed to write meta.json: %v", err)
+		}
 
 		if err == nil {
 			post := agent.GetCurrentPost()
-			os.WriteFile(jobDir+"/output.md", []byte(post.FinalContent), 0644)
+			if err := os.WriteFile(jobDir+"/output.md", []byte(post.FinalContent), 0644); err != nil {
+				log.Printf("failed to write output.md: %v", err)
+			}
 		}
 	}()
 

--- a/ops/helm/pedrocli/templates/configmap.yaml
+++ b/ops/helm/pedrocli/templates/configmap.yaml
@@ -37,5 +37,11 @@ data:
       },
       "init": {
         "skip_checks": true
+      },
+      "debug": {
+        "keep_temp_files": {{ .Values.pedrocli.config.debug.keepTempFiles }}
+      },
+      "github": {
+        "token": ""
       }
     }

--- a/ops/helm/pedrocli/values.yaml
+++ b/ops/helm/pedrocli/values.yaml
@@ -2,7 +2,8 @@
 # Override with: helm upgrade --install pedrocli ./ops/helm/pedrocli \
 #   --set-string pedrocli.env.DATABASE_URL="$DATABASE_URL" \
 #   --set-string pedrocli.env.NOTION_TOKEN="$NOTION_TOKEN" \
-#   --set-string pedrocli.env.CAL_API_KEY="$CAL_API_KEY"
+#   --set-string pedrocli.env.CAL_API_KEY="$CAL_API_KEY" \
+#   --set-string pedrocli.env.GITHUB_TOKEN="$GITHUB_TOKEN"
 #
 # Secrets are stored in OpenBao at secret/apps/pedrocli and injected by deploy.sh.
 
@@ -16,7 +17,7 @@ pedrocli:
   config:
     model:
       type: llamacpp
-      modelName: gptoss20b2
+      modelName: gpt-oss-20b
       # pedrogpt runs llama.cpp and is reachable via Tailscale
       serverUrl: "http://100.121.229.114:8080"
       temperature: 0.2
@@ -29,6 +30,8 @@ pedrocli:
     web:
       port: 8080
       host: "0.0.0.0"
+    debug:
+      keepTempFiles: true
 
   # Environment variables (set via --set-string at deploy time)
   # Pulled from OpenBao (secret/apps/pedrocli) by ops/scripts/deploy.sh
@@ -36,6 +39,7 @@ pedrocli:
     DATABASE_URL: ""
     NOTION_TOKEN: ""
     CAL_API_KEY: ""
+    GITHUB_TOKEN: ""
 
   resources:
     requests:

--- a/ops/scripts/deploy.sh
+++ b/ops/scripts/deploy.sh
@@ -41,6 +41,11 @@ if [[ -z "${CAL_API_KEY:-}" ]]; then
     CAL_API_KEY="$(_bao_get cal_api_key)"
 fi
 
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+    echo "==> Fetching GITHUB_TOKEN from OpenBao..."
+    GITHUB_TOKEN="$(_bao_get github_credential)"
+fi
+
 if [[ -z "${DATABASE_URL:-}" ]]; then
     echo "ERROR: DATABASE_URL not found in OpenBao (${OPENBAO_ADDR} ${OPENBAO_SECRET_PATH}) and not set in environment." >&2
     exit 1
@@ -57,6 +62,10 @@ fi
 
 if [[ -n "${CAL_API_KEY:-}" ]]; then
     EXTRA_ARGS+=(--set-string "pedrocli.env.CAL_API_KEY=${CAL_API_KEY}")
+fi
+
+if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    EXTRA_ARGS+=(--set-string "pedrocli.env.GITHUB_TOKEN=${GITHUB_TOKEN}")
 fi
 
 # Pass any additional args (e.g. --dry-run, --set foo=bar)

--- a/pkg/agents/builder_phased.go
+++ b/pkg/agents/builder_phased.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"os"
 
 	"github.com/soypete/pedrocli/pkg/artifacts"
 	"github.com/soypete/pedrocli/pkg/config"
@@ -143,8 +144,14 @@ func (b *BuilderPhasedAgent) Execute(ctx context.Context, input map[string]inter
 		b.RegisterTool(researchLinksTool)
 	}
 
+	// Get GitHub token
+	githubToken := b.config.GitHub.Token
+	if githubToken == "" {
+		githubToken = os.Getenv("GITHUB_TOKEN")
+	}
+
 	// Register GitHub tool
-	githubTool := tools.NewGitHubTool("")
+	githubTool := tools.NewGitHubToolWithToken("", githubToken)
 	b.RegisterTool(githubTool)
 
 	// Create job with workflow_type
@@ -189,7 +196,7 @@ func (b *BuilderPhasedAgent) Execute(ctx context.Context, input map[string]inter
 		// Update tool work directories
 		if githubTool, ok := b.tools["github"].(*tools.GitHubTool); ok {
 			// Re-register with correct workDir
-			b.RegisterTool(tools.NewGitHubTool(workDir))
+			b.RegisterTool(tools.NewGitHubToolWithToken(workDir, githubToken))
 			_ = githubTool // silence unused warning
 		}
 

--- a/pkg/agents/reviewer_phased.go
+++ b/pkg/agents/reviewer_phased.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 
@@ -156,8 +157,14 @@ func (r *ReviewerPhasedAgent) Execute(ctx context.Context, input map[string]inte
 		return nil, fmt.Errorf("missing 'pr_number' or 'branch' in input")
 	}
 
+	// Get GitHub token
+	githubToken := r.config.GitHub.Token
+	if githubToken == "" {
+		githubToken = os.Getenv("GITHUB_TOKEN")
+	}
+
 	// Register GitHub tool
-	githubTool := tools.NewGitHubTool("")
+	githubTool := tools.NewGitHubToolWithToken("", githubToken)
 	r.RegisterTool(githubTool)
 
 	// Create job
@@ -197,7 +204,7 @@ func (r *ReviewerPhasedAgent) Execute(ctx context.Context, input map[string]inte
 		}
 
 		// Update GitHub tool with correct workDir
-		r.RegisterTool(tools.NewGitHubTool(workDir))
+		r.RegisterTool(tools.NewGitHubToolWithToken(workDir, githubToken))
 
 		// Build initial prompt
 		initialPrompt := r.buildInitialPrompt(input)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	Model       ModelConfig       `json:"model"`
 	Execution   ExecutionConfig   `json:"execution"`
 	Git         GitConfig         `json:"git"`
+	GitHub      GitHubConfig      `json:"github"`
 	Tools       ToolsConfig       `json:"tools"`
 	Project     ProjectConfig     `json:"project"`
 	Limits      LimitsConfig      `json:"limits"`
@@ -89,6 +90,11 @@ type GitConfig struct {
 	AlwaysDraftPR bool   `json:"always_draft_pr"`
 	BranchPrefix  string `json:"branch_prefix"`
 	Remote        string `json:"remote"`
+}
+
+// GitHubConfig contains GitHub API settings
+type GitHubConfig struct {
+	Token string `json:"token,omitempty"` // GitHub personal access token (prefer env var GITHUB_TOKEN)
 }
 
 // ToolsConfig contains tool settings

--- a/pkg/tools/github.go
+++ b/pkg/tools/github.go
@@ -437,6 +437,8 @@ func parsePRURL(urlStr string) (owner, repo string, prNum int, err error) {
 
 	urlStr = strings.TrimPrefix(urlStr, "https://")
 	urlStr = strings.TrimPrefix(urlStr, "http://")
+	urlStr = strings.TrimPrefix(urlStr, "github.com/")
+	urlStr = strings.TrimPrefix(urlStr, "github.com")
 	urlStr = strings.TrimSuffix(urlStr, "/")
 	urlStr = strings.TrimSuffix(urlStr, "/files")
 	urlStr = strings.TrimSuffix(urlStr, "/diff")

--- a/pkg/tools/github.go
+++ b/pkg/tools/github.go
@@ -454,7 +454,9 @@ func parsePRURL(urlStr string) (owner, repo string, prNum int, err error) {
 	repo = parts[1]
 	prNumStr := parts[3]
 
-	fmt.Sscanf(prNumStr, "%d", &prNum)
+	if _, err := fmt.Sscanf(prNumStr, "%d", &prNum); err != nil {
+		return "", "", 0, fmt.Errorf("invalid PR number format: %s", prNumStr)
+	}
 	if prNum == 0 {
 		return "", "", 0, fmt.Errorf("invalid PR number: %s", prNumStr)
 	}

--- a/pkg/tools/github.go
+++ b/pkg/tools/github.go
@@ -1,3 +1,63 @@
+// Package tools provides the GitHub tool for interacting with GitHub via API or CLI.
+//
+// # Usage
+//
+// The GitHub tool supports two authentication methods:
+//
+//  1. gh CLI (default): Uses the authenticated gh session. Requires `gh auth login`.
+//     - Automatically used when no token is provided
+//     - Supports both public and private repos the user has access to
+//
+//  2. GitHub Token: Direct API access with a personal access token or GitHub App token.
+//     - Use NewGitHubToolWithToken(workDir, token) to enable
+//     - Useful for CI/automation or fine-grained access control
+//
+// # Actions
+//
+// The tool supports the following actions via the "action" argument:
+//
+//   - pr_fetch: Fetch pull request details (title, body, diff, files changed)
+//     Required: repo (owner/repo) or url (https://github.com/.../pull/123)
+//     Optional: pr_number, include_diff (bool)
+//
+//   - pr_checkout: Checkout a PR locally using gh CLI
+//     Required: pr_number
+//     Optional: repo
+//
+//   - issue_fetch: Fetch issue details (title, body, labels, comments)
+//     Required: repo, issue_number
+//
+//   - pr_create: Create a new pull request (requires gh CLI)
+//     Required: title
+//     Optional: body, head, base, draft (default: true)
+//
+//   - pr_comment: Add a comment to a PR
+//     Required: pr_number, body
+//     Optional: repo
+//
+// # Examples
+//
+//	// Using gh CLI (requires authentication)
+//	tool := NewGitHubTool("/path/to/repo")
+//	result, _ := tool.Execute(ctx, map[string]interface{}{
+//	    "action":    "pr_fetch",
+//	    "repo":      "owner/repo",
+//	    "pr_number": 123,
+//	})
+//
+//	// Using token for API access
+//	tool := NewGitHubToolWithToken("/path/to/repo", "ghp_...")
+//
+//	// Fetch by URL
+//	result, _ := tool.Execute(ctx, map[string]interface{}{
+//	    "action": "pr_fetch",
+//	    "url":    "https://github.com/owner/repo/pull/123",
+//	})
+//
+// # Capabilities
+//
+// The tool requires the "gh" capability for CLI-based actions.
+// HTTP client mode works with any network-capable environment.
 package tools
 
 import (
@@ -8,17 +68,33 @@ import (
 	"strings"
 
 	"github.com/soypete/pedrocli/pkg/logits"
+	"github.com/soypete/pedrocli/pkg/tools/github"
 )
 
-// GitHubTool provides GitHub CLI operations for fetching PRs and issues
+// GitHubTool provides GitHub API operations for fetching PRs and issues
 type GitHubTool struct {
-	workDir string
+	workDir     string
+	githubToken string
+	httpClient  *github.Client
 }
 
-// NewGitHubTool creates a new GitHub tool
+// NewGitHubTool creates a new GitHub tool (legacy CLI-based)
 func NewGitHubTool(workDir string) *GitHubTool {
 	return &GitHubTool{
 		workDir: workDir,
+	}
+}
+
+// NewGitHubToolWithToken creates a new GitHub tool with HTTP API client
+func NewGitHubToolWithToken(workDir, token string) *GitHubTool {
+	var httpClient *github.Client
+	if token != "" {
+		httpClient = github.NewClient(token)
+	}
+	return &GitHubTool{
+		workDir:     workDir,
+		githubToken: token,
+		httpClient:  httpClient,
 	}
 }
 
@@ -29,34 +105,33 @@ func (g *GitHubTool) Name() string {
 
 // Description returns the tool description
 func (g *GitHubTool) Description() string {
-	return `Interact with GitHub using the gh CLI.
+	return `Interact with GitHub using the API.
 
 Actions:
 - pr_fetch: Fetch pull request details
-  Args: pr_number (int) OR branch (string)
+  Args: repo (string, "owner/repo"), pr_number (int) OR url (string, "https://github.com/owner/repo/pull/123")
   Returns: PR title, body, diff, files changed, review status
 
-- pr_checkout: Checkout a pull request locally
-  Args: pr_number (int)
+- pr_checkout: Checkout a pull request locally (requires gh CLI)
+  Args: pr_number (int), repo (string, optional)
   Returns: Local branch name
 
 - issue_fetch: Fetch issue details
-  Args: issue_number (int)
+  Args: repo (string), issue_number (int)
   Returns: Issue title, body, labels, comments
 
-- pr_create: Create a draft pull request
-  Args: title (string), body (string), draft (bool, default true)
+- pr_create: Create a pull request
+  Args: repo (string), title (string), body (string), head (string), base (string), draft (bool)
   Returns: PR URL
 
 - pr_comment: Add a comment to a PR
-  Args: pr_number (int), body (string)
+  Args: repo (string), pr_number (int), body (string)
   Returns: Comment URL
 
 Examples:
-{"tool": "github", "args": {"action": "pr_fetch", "pr_number": 123}}
-{"tool": "github", "args": {"action": "issue_fetch", "issue_number": 456}}
-{"tool": "github", "args": {"action": "pr_checkout", "pr_number": 123}}
-{"tool": "github", "args": {"action": "pr_create", "title": "Add feature X", "body": "Description...", "draft": true}}`
+{"tool": "github", "args": {"action": "pr_fetch", "repo": "owner/repo", "pr_number": 123}}
+{"tool": "github", "args": {"action": "pr_fetch", "url": "https://github.com/owner/repo/pull/123"}}
+{"tool": "github", "args": {"action": "issue_fetch", "repo": "owner/repo", "issue_number": 456}}`
 }
 
 // Execute executes the GitHub tool
@@ -119,6 +194,117 @@ type IssueComment struct {
 
 // prFetch fetches PR details
 func (g *GitHubTool) prFetch(ctx context.Context, args map[string]interface{}) (*Result, error) {
+	repo, _ := args["repo"].(string)
+	urlStr, _ := args["url"].(string)
+
+	// Handle URL parameter - extract repo and PR number
+	if urlStr != "" {
+		owner, repoName, prNum, err := parsePRURL(urlStr)
+		if err != nil {
+			return &Result{Success: false, Error: fmt.Sprintf("failed to parse PR URL: %v", err)}, nil
+		}
+		repo = fmt.Sprintf("%s/%s", owner, repoName)
+		args["pr_number"] = prNum
+	}
+
+	// Use HTTP client if available
+	if g.httpClient != nil && repo != "" {
+		return g.prFetchHTTP(ctx, args)
+	}
+
+	// Fallback to CLI
+	return g.prFetchCLI(ctx, args)
+}
+
+// prFetchHTTP fetches PR using GitHub API
+func (g *GitHubTool) prFetchHTTP(ctx context.Context, args map[string]interface{}) (*Result, error) {
+	repo, _ := args["repo"].(string)
+	owner, repoName, err := github.ParseRepo(repo)
+	if err != nil {
+		return &Result{Success: false, Error: fmt.Sprintf("invalid repo format: %v", err)}, nil
+	}
+
+	var prNum int
+	if prNumFloat, ok := args["pr_number"].(float64); ok {
+		prNum = int(prNumFloat)
+	} else if prNumInt, ok := args["pr_number"].(int); ok {
+		prNum = prNumInt
+	} else {
+		return &Result{Success: false, Error: "missing 'pr_number' parameter"}, nil
+	}
+
+	// Fetch PR details
+	pr, err := g.httpClient.FetchPR(ctx, owner, repoName, prNum)
+	if err != nil {
+		return &Result{Success: false, Error: fmt.Sprintf("failed to fetch PR: %v", err)}, nil
+	}
+
+	// Fetch files
+	files, err := g.httpClient.FetchPRFiles(ctx, owner, repoName, prNum)
+	if err != nil {
+		return &Result{Success: false, Error: fmt.Sprintf("failed to fetch PR files: %v", err)}, nil
+	}
+
+	filePaths := make([]string, len(files))
+	for i, f := range files {
+		filePaths[i] = f.Filename
+	}
+
+	// Optionally fetch diff
+	var diff string
+	if includeDiff, ok := args["include_diff"].(bool); ok && includeDiff {
+		diff, err = g.httpClient.FetchPRDiff(ctx, owner, repoName, prNum)
+		if err != nil {
+			return &Result{Success: false, Error: fmt.Sprintf("failed to fetch diff: %v", err)}, nil
+		}
+	}
+
+	prInfo := PRInfo{
+		Number:     pr.Number,
+		Title:      pr.Title,
+		Body:       pr.Body,
+		State:      pr.State,
+		HeadBranch: pr.Head.Ref,
+		BaseBranch: pr.Base.Ref,
+		Author:     pr.User.Login,
+		URL:        pr.URL,
+		Files:      filePaths,
+		Additions:  pr.Additions,
+		Deletions:  pr.Deletions,
+		Diff:       diff,
+	}
+
+	// Format output
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("PR #%d: %s\n", prInfo.Number, prInfo.Title))
+	sb.WriteString(fmt.Sprintf("Author: %s | State: %s\n", prInfo.Author, prInfo.State))
+	sb.WriteString(fmt.Sprintf("Branch: %s → %s\n", prInfo.HeadBranch, prInfo.BaseBranch))
+	sb.WriteString(fmt.Sprintf("Changes: +%d -%d in %d files\n", prInfo.Additions, prInfo.Deletions, len(prInfo.Files)))
+	sb.WriteString(fmt.Sprintf("URL: %s\n", prInfo.URL))
+	sb.WriteString("\n## Description\n")
+	sb.WriteString(prInfo.Body)
+	sb.WriteString("\n\n## Files Changed\n")
+	for _, f := range prInfo.Files {
+		sb.WriteString(fmt.Sprintf("- %s\n", f))
+	}
+
+	if diff != "" {
+		sb.WriteString("\n## Diff\n```diff\n")
+		sb.WriteString(diff)
+		sb.WriteString("\n```")
+	}
+
+	return &Result{
+		Success: true,
+		Output:  sb.String(),
+		Data: map[string]interface{}{
+			"pr_info": prInfo,
+		},
+	}, nil
+}
+
+// prFetchCLI fetches PR using gh CLI (fallback)
+func (g *GitHubTool) prFetchCLI(ctx context.Context, args map[string]interface{}) (*Result, error) {
 	var prIdentifier string
 	repo, _ := args["repo"].(string)
 
@@ -242,6 +428,40 @@ func (g *GitHubTool) prFetch(ctx context.Context, args map[string]interface{}) (
 	}, nil
 }
 
+// parsePRURL parses a GitHub PR URL and extracts owner, repo, and PR number
+func parsePRURL(urlStr string) (owner, repo string, prNum int, err error) {
+	// Support formats:
+	// https://github.com/owner/repo/pull/123
+	// https://github.com/owner/repo/pull/123/files
+	// github.com/owner/repo/pull/123
+
+	urlStr = strings.TrimPrefix(urlStr, "https://")
+	urlStr = strings.TrimPrefix(urlStr, "http://")
+	urlStr = strings.TrimSuffix(urlStr, "/")
+	urlStr = strings.TrimSuffix(urlStr, "/files")
+	urlStr = strings.TrimSuffix(urlStr, "/diff")
+
+	parts := strings.Split(urlStr, "/")
+	if len(parts) != 4 {
+		return "", "", 0, fmt.Errorf("invalid PR URL format: %s", urlStr)
+	}
+
+	if parts[2] != "pull" {
+		return "", "", 0, fmt.Errorf("URL does not point to a pull request: %s", urlStr)
+	}
+
+	owner = parts[0]
+	repo = parts[1]
+	prNumStr := parts[3]
+
+	fmt.Sscanf(prNumStr, "%d", &prNum)
+	if prNum == 0 {
+		return "", "", 0, fmt.Errorf("invalid PR number: %s", prNumStr)
+	}
+
+	return owner, repo, prNum, nil
+}
+
 // prCheckout checks out a PR locally
 func (g *GitHubTool) prCheckout(ctx context.Context, args map[string]interface{}) (*Result, error) {
 	var prNum int
@@ -285,6 +505,102 @@ func (g *GitHubTool) prCheckout(ctx context.Context, args map[string]interface{}
 
 // issueFetch fetches issue details
 func (g *GitHubTool) issueFetch(ctx context.Context, args map[string]interface{}) (*Result, error) {
+	repo, _ := args["repo"].(string)
+
+	// Use HTTP client if available and repo specified
+	if g.httpClient != nil && repo != "" {
+		return g.issueFetchHTTP(ctx, args)
+	}
+
+	// Fallback to CLI
+	return g.issueFetchCLI(ctx, args)
+}
+
+// issueFetchHTTP fetches issue using GitHub API
+func (g *GitHubTool) issueFetchHTTP(ctx context.Context, args map[string]interface{}) (*Result, error) {
+	repo, _ := args["repo"].(string)
+	owner, repoName, err := github.ParseRepo(repo)
+	if err != nil {
+		return &Result{Success: false, Error: fmt.Sprintf("invalid repo format: %v", err)}, nil
+	}
+
+	var issueNum int
+	if num, ok := args["issue_number"].(float64); ok {
+		issueNum = int(num)
+	} else if num, ok := args["issue_number"].(int); ok {
+		issueNum = num
+	} else {
+		return &Result{Success: false, Error: "missing 'issue_number' parameter"}, nil
+	}
+
+	// Fetch issue
+	issue, err := g.httpClient.FetchIssue(ctx, owner, repoName, issueNum)
+	if err != nil {
+		return &Result{Success: false, Error: fmt.Sprintf("failed to fetch issue: %v", err)}, nil
+	}
+
+	// Fetch comments
+	comments, err := g.httpClient.FetchIssueComments(ctx, owner, repoName, issueNum)
+	if err != nil {
+		return &Result{Success: false, Error: fmt.Sprintf("failed to fetch comments: %v", err)}, nil
+	}
+
+	// Extract labels
+	labels := make([]string, len(issue.Labels))
+	for i, l := range issue.Labels {
+		labels[i] = l.Name
+	}
+
+	// Convert comments
+	issueComments := make([]IssueComment, len(comments))
+	for i, c := range comments {
+		issueComments[i] = IssueComment{
+			Author:    c.User.Login,
+			Body:      c.Body,
+			CreatedAt: c.CreatedAt,
+		}
+	}
+
+	issueInfo := IssueInfo{
+		Number:   issue.Number,
+		Title:    issue.Title,
+		Body:     issue.Body,
+		State:    issue.State,
+		Author:   issue.User.Login,
+		Labels:   labels,
+		URL:      issue.URL,
+		Comments: issueComments,
+	}
+
+	// Format output
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Issue #%d: %s\n", issueInfo.Number, issueInfo.Title))
+	sb.WriteString(fmt.Sprintf("Author: %s | State: %s\n", issueInfo.Author, issueInfo.State))
+	if len(issueInfo.Labels) > 0 {
+		sb.WriteString(fmt.Sprintf("Labels: %s\n", strings.Join(issueInfo.Labels, ", ")))
+	}
+	sb.WriteString(fmt.Sprintf("URL: %s\n", issueInfo.URL))
+	sb.WriteString("\n## Description\n")
+	sb.WriteString(issueInfo.Body)
+
+	if len(issueInfo.Comments) > 0 {
+		sb.WriteString("\n\n## Comments\n")
+		for _, c := range issueInfo.Comments {
+			sb.WriteString(fmt.Sprintf("\n### @%s (%s)\n%s\n", c.Author, c.CreatedAt, c.Body))
+		}
+	}
+
+	return &Result{
+		Success: true,
+		Output:  sb.String(),
+		Data: map[string]interface{}{
+			"issue_info": issueInfo,
+		},
+	}, nil
+}
+
+// issueFetchCLI fetches issue using gh CLI (fallback)
+func (g *GitHubTool) issueFetchCLI(ctx context.Context, args map[string]interface{}) (*Result, error) {
 	var issueNum int
 	if num, ok := args["issue_number"].(float64); ok {
 		issueNum = int(num)

--- a/pkg/tools/github/api_client.go
+++ b/pkg/tools/github/api_client.go
@@ -1,0 +1,302 @@
+// Package github provides a GitHub API client for programmatic access to GitHub.
+//
+// This package is used by the GitHub tool to interact with GitHub's REST API.
+// It supports fetching PRs, issues, files, and creating PRs/comments.
+//
+// # Authentication
+//
+// Provide a personal access token (PAT) or GitHub App token to NewClient().
+// The token should have appropriate scopes:
+//
+//   - repo: Full read/write access to repositories
+//   - read:org: Read organization information
+//
+// # Usage
+//
+//	client := github.NewClient("ghp_...")
+//
+//	// Fetch a PR
+//	pr, err := client.FetchPR(ctx, "owner", "repo", 123)
+//
+//	// Fetch PR files
+//	files, err := client.FetchPRFiles(ctx, "owner", "repo", 123)
+//
+//	// Fetch issue with comments
+//	issue, err := client.FetchIssue(ctx, "owner", "repo", 456)
+//	comments, err := client.FetchIssueComments(ctx, "owner", "repo", 456)
+//
+//	// Create a PR
+//	pr, err := client.CreatePR(ctx, "owner", "repo", github.CreatePRRequest{
+//	    Title: "Add feature",
+//	    Body:  "Description",
+//	    Head:  "feature-branch",
+//	    Base:  "main",
+//	    Draft: true,
+//	})
+//
+// # Rate Limiting
+//
+// The GitHub API imposes rate limits (5000 requests/hour for authenticated requests).
+// This client does not implement rate limiting - add a rate limiter if needed.
+//
+// # Error Handling
+//
+// All methods return errors that include the HTTP status code and response body
+// for debugging failed requests.
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+const (
+	APIBaseURL = "https://api.github.com"
+)
+
+type Client struct {
+	token      string
+	httpClient *http.Client
+}
+
+func NewClient(token string) *Client {
+	return &Client{
+		token:      token,
+		httpClient: &http.Client{},
+	}
+}
+
+func (c *Client) doRequest(ctx context.Context, method, path string, body interface{}) ([]byte, error) {
+	var reqBody io.Reader
+	if body != nil {
+		jsonBody, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal request body: %w", err)
+		}
+		reqBody = bytes.NewBuffer(jsonBody)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, APIBaseURL+path, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("GitHub API error (status %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	return respBody, nil
+}
+
+type PullRequest struct {
+	Number    int    `json:"number"`
+	Title     string `json:"title"`
+	Body      string `json:"body"`
+	State     string `json:"state"`
+	Head      Branch `json:"head"`
+	Base      Branch `json:"base"`
+	User      User   `json:"user"`
+	URL       string `json:"html_url"`
+	Additions int    `json:"additions"`
+	Deletions int    `json:"deletions"`
+	Files     []File `json:"files"`
+}
+
+type Branch struct {
+	Ref string `json:"ref"`
+	SHA string `json:"sha"`
+}
+
+type User struct {
+	Login string `json:"login"`
+}
+
+type File struct {
+	SHA       string `json:"sha"`
+	Filename  string `json:"filename"`
+	Status    string `json:"status"`
+	Additions int    `json:"additions"`
+	Deletions int    `json:"deletions"`
+	Patch     string `json:"patch"`
+}
+
+type Issue struct {
+	Number   int       `json:"number"`
+	Title    string    `json:"title"`
+	Body     string    `json:"body"`
+	State    string    `json:"state"`
+	User     User      `json:"user"`
+	Labels   []Label   `json:"labels"`
+	URL      string    `json:"html_url"`
+	Comments []Comment `json:"comments"`
+}
+
+type Label struct {
+	Name string `json:"name"`
+}
+
+type Comment struct {
+	ID        int    `json:"id"`
+	Body      string `json:"body"`
+	User      User   `json:"user"`
+	CreatedAt string `json:"created_at"`
+}
+
+type CreatePRRequest struct {
+	Title string `json:"title"`
+	Body  string `json:"body"`
+	Head  string `json:"head"`
+	Base  string `json:"base"`
+	Draft bool   `json:"draft"`
+}
+
+type CreateCommentRequest struct {
+	Body string `json:"body"`
+}
+
+func (c *Client) FetchPR(ctx context.Context, owner, repo string, prNum int) (*PullRequest, error) {
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, repo, prNum)
+	respBody, err := c.doRequest(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var pr PullRequest
+	if err := json.Unmarshal(respBody, &pr); err != nil {
+		return nil, fmt.Errorf("failed to parse PR response: %w", err)
+	}
+
+	return &pr, nil
+}
+
+func (c *Client) FetchPRFiles(ctx context.Context, owner, repo string, prNum int) ([]File, error) {
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/files", owner, repo, prNum)
+	respBody, err := c.doRequest(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var files []File
+	if err := json.Unmarshal(respBody, &files); err != nil {
+		return nil, fmt.Errorf("failed to parse files response: %w", err)
+	}
+
+	return files, nil
+}
+
+func (c *Client) FetchPRDiff(ctx context.Context, owner, repo string, prNum int) (string, error) {
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, repo, prNum)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", APIBaseURL+path, nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Accept", "application/vnd.github.v3.diff")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("GitHub API error (status %d)", resp.StatusCode)
+	}
+
+	diffBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(diffBody), nil
+}
+
+func (c *Client) FetchIssue(ctx context.Context, owner, repo string, issueNum int) (*Issue, error) {
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d", owner, repo, issueNum)
+	respBody, err := c.doRequest(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var issue Issue
+	if err := json.Unmarshal(respBody, &issue); err != nil {
+		return nil, fmt.Errorf("failed to parse issue response: %w", err)
+	}
+
+	return &issue, nil
+}
+
+func (c *Client) FetchIssueComments(ctx context.Context, owner, repo string, issueNum int) ([]Comment, error) {
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d/comments", owner, repo, issueNum)
+	respBody, err := c.doRequest(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var comments []Comment
+	if err := json.Unmarshal(respBody, &comments); err != nil {
+		return nil, fmt.Errorf("failed to parse comments response: %w", err)
+	}
+
+	return comments, nil
+}
+
+func (c *Client) CreatePR(ctx context.Context, owner, repo string, req CreatePRRequest) (*PullRequest, error) {
+	path := fmt.Sprintf("/repos/%s/%s/pulls", owner, repo)
+	respBody, err := c.doRequest(ctx, "POST", path, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var pr PullRequest
+	if err := json.Unmarshal(respBody, &pr); err != nil {
+		return nil, fmt.Errorf("failed to parse PR response: %w", err)
+	}
+
+	return &pr, nil
+}
+
+func (c *Client) AddComment(ctx context.Context, owner, repo string, issueNum int, body string) (*Comment, error) {
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d/comments", owner, repo, issueNum)
+	respBody, err := c.doRequest(ctx, "POST", path, CreateCommentRequest{Body: body})
+	if err != nil {
+		return nil, err
+	}
+
+	var comment Comment
+	if err := json.Unmarshal(respBody, &comment); err != nil {
+		return nil, fmt.Errorf("failed to parse comment response: %w", err)
+	}
+
+	return &comment, nil
+}
+
+func ParseRepo(repo string) (owner, name string, err error) {
+	parts := strings.Split(repo, "/")
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("invalid repo format: %s (expected owner/repo)", repo)
+	}
+	return parts[0], parts[1], nil
+}

--- a/pkg/tools/github/api_client_test.go
+++ b/pkg/tools/github/api_client_test.go
@@ -1,0 +1,171 @@
+package github
+
+import (
+	"testing"
+)
+
+func TestNewClient(t *testing.T) {
+	client := NewClient("test-token")
+	if client == nil {
+		t.Fatal("NewClient() returned nil")
+	}
+	if client.token != "test-token" {
+		t.Errorf("token = %v, want test-token", client.token)
+	}
+	if client.httpClient == nil {
+		t.Error("httpClient should not be nil")
+	}
+}
+
+func TestParseRepo(t *testing.T) {
+	tests := []struct {
+		name      string
+		repo      string
+		wantOwner string
+		wantName  string
+		wantErr   bool
+	}{
+		{
+			name:      "valid repo format",
+			repo:      "owner/repo",
+			wantOwner: "owner",
+			wantName:  "repo",
+			wantErr:   false,
+		},
+		{
+			name:      "valid with hyphens",
+			repo:      "my-org/my-repo-name",
+			wantOwner: "my-org",
+			wantName:  "my-repo-name",
+			wantErr:   false,
+		},
+		{
+			name:    "invalid - no slash",
+			repo:    "owner-repo",
+			wantErr: true,
+		},
+		{
+			name:    "invalid - too many parts",
+			repo:    "owner/repo/extra",
+			wantErr: true,
+		},
+		{
+			name:    "invalid - empty",
+			repo:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owner, name, err := ParseRepo(tt.repo)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseRepo() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if owner != tt.wantOwner {
+					t.Errorf("owner = %v, want %v", owner, tt.wantOwner)
+				}
+				if name != tt.wantName {
+					t.Errorf("name = %v, want %v", name, tt.wantName)
+				}
+			}
+		})
+	}
+}
+
+func TestPullRequestStruct(t *testing.T) {
+	pr := PullRequest{
+		Number:    1,
+		Title:     "Test PR",
+		Body:      "PR body",
+		State:     "open",
+		Head:      Branch{Ref: "feature", SHA: "abc123"},
+		Base:      Branch{Ref: "main", SHA: "def456"},
+		User:      User{Login: "testuser"},
+		URL:       "https://github.com/owner/repo/pull/1",
+		Additions: 100,
+		Deletions: 50,
+	}
+
+	if pr.Number != 1 {
+		t.Errorf("Number = %v, want 1", pr.Number)
+	}
+	if pr.Head.Ref != "feature" {
+		t.Errorf("Head.Ref = %v, want feature", pr.Head.Ref)
+	}
+	if pr.User.Login != "testuser" {
+		t.Errorf("User.Login = %v, want testuser", pr.User.Login)
+	}
+}
+
+func TestFileStruct(t *testing.T) {
+	file := File{
+		SHA:       "abc123",
+		Filename:  "src/main.go",
+		Status:    "modified",
+		Additions: 10,
+		Deletions: 5,
+		Patch:     "patch content",
+	}
+
+	if file.Filename != "src/main.go" {
+		t.Errorf("Filename = %v, want src/main.go", file.Filename)
+	}
+	if file.Status != "modified" {
+		t.Errorf("Status = %v, want modified", file.Status)
+	}
+}
+
+func TestIssueStruct(t *testing.T) {
+	issue := Issue{
+		Number: 1,
+		Title:  "Test Issue",
+		Body:   "Issue body",
+		State:  "open",
+		User:   User{Login: "testuser"},
+		Labels: []Label{{Name: "bug"}, {Name: "priority"}},
+		URL:    "https://github.com/owner/repo/issues/1",
+		Comments: []Comment{
+			{ID: 1, Body: "comment", User: User{Login: "commenter"}, CreatedAt: "2024-01-01"},
+		},
+	}
+
+	if issue.Number != 1 {
+		t.Errorf("Number = %v, want 1", issue.Number)
+	}
+	if len(issue.Labels) != 2 {
+		t.Errorf("Labels length = %v, want 2", len(issue.Labels))
+	}
+	if len(issue.Comments) != 1 {
+		t.Errorf("Comments length = %v, want 1", len(issue.Comments))
+	}
+}
+
+func TestCreatePRRequestStruct(t *testing.T) {
+	req := CreatePRRequest{
+		Title: "New PR",
+		Body:  "PR description",
+		Head:  "feature-branch",
+		Base:  "main",
+		Draft: true,
+	}
+
+	if req.Title != "New PR" {
+		t.Errorf("Title = %v, want New PR", req.Title)
+	}
+	if !req.Draft {
+		t.Error("Draft should be true")
+	}
+}
+
+func TestCreateCommentRequestStruct(t *testing.T) {
+	req := CreateCommentRequest{
+		Body: "Test comment",
+	}
+
+	if req.Body != "Test comment" {
+		t.Errorf("Body = %v, want Test comment", req.Body)
+	}
+}

--- a/pkg/tools/github_test.go
+++ b/pkg/tools/github_test.go
@@ -1,0 +1,305 @@
+package tools
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGitHubToolName(t *testing.T) {
+	tool := NewGitHubTool("/tmp")
+	if tool.Name() != "github" {
+		t.Errorf("Name() = %v, want github", tool.Name())
+	}
+}
+
+func TestGitHubToolDescription(t *testing.T) {
+	tool := NewGitHubTool("/tmp")
+	desc := tool.Description()
+	if desc == "" {
+		t.Error("Description() should not be empty")
+	}
+	if len(desc) < 100 {
+		t.Error("Description() should be comprehensive")
+	}
+}
+
+func TestGitHubToolExecute_MissingAction(t *testing.T) {
+	tool := NewGitHubTool("/tmp")
+	ctx := context.Background()
+
+	result, err := tool.Execute(ctx, map[string]interface{}{})
+	if err != nil {
+		t.Errorf("Execute() error = %v", err)
+	}
+	if result.Success {
+		t.Error("Success = true, want false for missing action")
+	}
+	if result.Error == "" {
+		t.Error("Error should not be empty")
+	}
+}
+
+func TestGitHubToolExecute_UnknownAction(t *testing.T) {
+	tool := NewGitHubTool("/tmp")
+	ctx := context.Background()
+
+	result, err := tool.Execute(ctx, map[string]interface{}{
+		"action": "unknown_action",
+	})
+	if err != nil {
+		t.Errorf("Execute() error = %v", err)
+	}
+	if result.Success {
+		t.Error("Success = true, want false for unknown action")
+	}
+	if result.Error == "" {
+		t.Error("Error should not be empty")
+	}
+}
+
+func TestGitHubTool_NewGitHubToolWithToken(t *testing.T) {
+	tool := NewGitHubToolWithToken("/tmp", "test-token")
+	if tool.githubToken != "test-token" {
+		t.Errorf("githubToken = %v, want test-token", tool.githubToken)
+	}
+	if tool.httpClient == nil {
+		t.Error("httpClient should not be nil when token is provided")
+	}
+}
+
+func TestGitHubTool_NewGitHubToolWithEmptyToken(t *testing.T) {
+	tool := NewGitHubToolWithToken("/tmp", "")
+	if tool.httpClient != nil {
+		t.Error("httpClient should be nil when token is empty")
+	}
+}
+
+func TestParsePRURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		url       string
+		wantOwner string
+		wantRepo  string
+		wantNum   int
+		wantErr   bool
+	}{
+		{
+			name:      "standard https URL",
+			url:       "https://github.com/owner/repo/pull/123",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantNum:   123,
+			wantErr:   false,
+		},
+		{
+			name:      "URL without https",
+			url:       "github.com/owner/repo/pull/456",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantNum:   456,
+			wantErr:   false,
+		},
+		{
+			name:      "URL with files suffix",
+			url:       "https://github.com/owner/repo/pull/789/files",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantNum:   789,
+			wantErr:   false,
+		},
+		{
+			name:      "URL with diff suffix",
+			url:       "https://github.com/owner/repo/pull/100/diff",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+			wantNum:   100,
+			wantErr:   false,
+		},
+		{
+			name:    "invalid URL - not a PR",
+			url:     "https://github.com/owner/repo/issues/123",
+			wantErr: true,
+		},
+		{
+			name:    "invalid URL - wrong format",
+			url:     "https://github.com/owner/repo",
+			wantErr: true,
+		},
+		{
+			name:    "invalid URL - missing PR number",
+			url:     "https://github.com/owner/repo/pull/abc",
+			wantErr: true,
+		},
+		{
+			name:    "invalid URL - empty",
+			url:     "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owner, repo, num, err := parsePRURL(tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parsePRURL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if owner != tt.wantOwner {
+					t.Errorf("owner = %v, want %v", owner, tt.wantOwner)
+				}
+				if repo != tt.wantRepo {
+					t.Errorf("repo = %v, want %v", repo, tt.wantRepo)
+				}
+				if num != tt.wantNum {
+					t.Errorf("num = %v, want %v", num, tt.wantNum)
+				}
+			}
+		})
+	}
+}
+
+func TestGitHubToolMetadata(t *testing.T) {
+	tool := NewGitHubTool("/tmp")
+	metadata := tool.Metadata()
+
+	if metadata == nil {
+		t.Fatal("Metadata() returned nil")
+	}
+
+	if metadata.Schema == nil {
+		t.Error("Schema should not be nil")
+	}
+
+	if metadata.Category != CategoryVCS {
+		t.Errorf("Category = %v, want vcs", metadata.Category)
+	}
+
+	if len(metadata.Produces) == 0 {
+		t.Error("Produces should not be empty")
+	}
+}
+
+func TestGitHubToolExecute_PRCheckout_MissingNumber(t *testing.T) {
+	tool := NewGitHubTool("/tmp")
+	ctx := context.Background()
+
+	result, err := tool.Execute(ctx, map[string]interface{}{
+		"action": "pr_checkout",
+	})
+	if err != nil {
+		t.Errorf("Execute() error = %v", err)
+	}
+	if result.Success {
+		t.Error("Success = true, want false for missing pr_number")
+	}
+}
+
+func TestGitHubToolExecute_IssueFetch_MissingNumber(t *testing.T) {
+	tool := NewGitHubTool("/tmp")
+	ctx := context.Background()
+
+	result, err := tool.Execute(ctx, map[string]interface{}{
+		"action": "issue_fetch",
+	})
+	if err != nil {
+		t.Errorf("Execute() error = %v", err)
+	}
+	if result.Success {
+		t.Error("Success = true, want false for missing issue_number")
+	}
+}
+
+func TestGitHubToolExecute_PRCreate_MissingTitle(t *testing.T) {
+	tool := NewGitHubTool("/tmp")
+	ctx := context.Background()
+
+	result, err := tool.Execute(ctx, map[string]interface{}{
+		"action": "pr_create",
+	})
+	if err != nil {
+		t.Errorf("Execute() error = %v", err)
+	}
+	if result.Success {
+		t.Error("Success = true, want false for missing title")
+	}
+}
+
+func TestGitHubToolExecute_PRComment_MissingNumber(t *testing.T) {
+	tool := NewGitHubTool("/tmp")
+	ctx := context.Background()
+
+	result, err := tool.Execute(ctx, map[string]interface{}{
+		"action": "pr_comment",
+		"body":   "test comment",
+	})
+	if err != nil {
+		t.Errorf("Execute() error = %v", err)
+	}
+	if result.Success {
+		t.Error("Success = true, want false for missing pr_number")
+	}
+}
+
+func TestGitHubToolExecute_PRComment_MissingBody(t *testing.T) {
+	tool := NewGitHubTool("/tmp")
+	ctx := context.Background()
+
+	result, err := tool.Execute(ctx, map[string]interface{}{
+		"action":    "pr_comment",
+		"pr_number": 123,
+	})
+	if err != nil {
+		t.Errorf("Execute() error = %v", err)
+	}
+	if result.Success {
+		t.Error("Success = true, want false for missing body")
+	}
+}
+
+func TestGitHubTool_PRInfoStruct(t *testing.T) {
+	prInfo := PRInfo{
+		Number:     1,
+		Title:      "Test PR",
+		Body:       "Test body",
+		State:      "open",
+		HeadBranch: "feature",
+		BaseBranch: "main",
+		Author:     "testuser",
+		URL:        "https://github.com/owner/repo/pull/1",
+		Files:      []string{"file1.go", "file2.go"},
+		Additions:  100,
+		Deletions:  50,
+		Diff:       "diff content",
+	}
+
+	if prInfo.Number != 1 {
+		t.Errorf("Number = %v, want 1", prInfo.Number)
+	}
+	if len(prInfo.Files) != 2 {
+		t.Errorf("Files length = %v, want 2", len(prInfo.Files))
+	}
+}
+
+func TestGitHubTool_IssueInfoStruct(t *testing.T) {
+	issueInfo := IssueInfo{
+		Number:   1,
+		Title:    "Test Issue",
+		Body:     "Test body",
+		State:    "open",
+		Author:   "testuser",
+		Labels:   []string{"bug", "priority"},
+		URL:      "https://github.com/owner/repo/issues/1",
+		Comments: []IssueComment{{Author: "commenter", Body: "comment", CreatedAt: "2024-01-01"}},
+	}
+
+	if issueInfo.Number != 1 {
+		t.Errorf("Number = %v, want 1", issueInfo.Number)
+	}
+	if len(issueInfo.Labels) != 2 {
+		t.Errorf("Labels length = %v, want 2", len(issueInfo.Labels))
+	}
+	if len(issueInfo.Comments) != 1 {
+		t.Errorf("Comments length = %v, want 1", len(issueInfo.Comments))
+	}
+}

--- a/pkg/tools/setup.go
+++ b/pkg/tools/setup.go
@@ -1,6 +1,8 @@
 package tools
 
 import (
+	"os"
+
 	"github.com/soypete/pedrocli/pkg/config"
 )
 
@@ -24,6 +26,12 @@ type CodeToolsSetup struct {
 func NewCodeToolsSetup(cfg *config.Config, workDir string) *CodeToolsSetup {
 	registry := NewToolRegistry()
 
+	// Get GitHub token from config or environment variable
+	githubToken := cfg.GitHub.Token
+	if githubToken == "" {
+		githubToken = os.Getenv("GITHUB_TOKEN")
+	}
+
 	setup := &CodeToolsSetup{
 		Registry:     registry,
 		FileTool:     NewFileTool(),
@@ -33,7 +41,7 @@ func NewCodeToolsSetup(cfg *config.Config, workDir string) *CodeToolsSetup {
 		GitTool:      NewGitTool(workDir),
 		BashTool:     NewBashTool(cfg, workDir),
 		TestTool:     NewTestTool(workDir),
-		GitHubTool:   NewGitHubTool(workDir),
+		GitHubTool:   NewGitHubToolWithToken(workDir, githubToken),
 	}
 
 	// Register all tools with the registry for proper schemas


### PR DESCRIPTION
## Summary

- New GitHub tool for fetching PRs, issues, creating PRs, and commenting
- HTTP API client for direct GitHub API access (supports private repos)
- Fallback to gh CLI for users with authenticated sessions
- Package-level documentation explaining usage and authentication
- Tests for tool operations, API client, and edge cases
- Wired up in setup.go, app.go, builder_phased.go, reviewer_phased.go

## Changes

-  - Main tool implementation
-  - GitHub API client
-  - Tool tests
-  - Client tests
- Config updates in , ==> Fetching DATABASE_URL from OpenBao...
==> Fetching NOTION_TOKEN from OpenBao...
==> Fetching CAL_API_KEY from OpenBao...
==> Fetching GITHUB_TOKEN from OpenBao...

## Testing

- All tests pass: `make test-quick`
- go vet passes